### PR TITLE
Added CVE references and enable CVE-based catalog search

### DIFF
--- a/docs/modules/exploit/linux/telnet/gnu_inetutils_telnetd_auth_bypass.md
+++ b/docs/modules/exploit/linux/telnet/gnu_inetutils_telnetd_auth_bypass.md
@@ -1,13 +1,20 @@
-# `exploit/linux/telnet/gnu_inetutils_telnetd_auth_bypass`
+# `exploit/linux/telnet/gnu_inetutils_telnetd_auth_bypass  (CVE-2026-24061)`
 
 ## Overview
+
 This module targets GNU `inetutils` `telnetd` authentication bypass behavior through TELNET `NEW-ENVIRON` negotiation.  
 It creates an interactive Moonlight session and injects a controlled `USER` value during environment subnegotiation.
 
 ## Module Path
+
 `exploit/linux/telnet/gnu_inetutils_telnetd_auth_bypass`
 
+## CVE
+
+- `CVE-2026-24061`
+
 ## What The Module Does
+
 - Connects to a TELNET service over TCP.
 - Handles TELNET option negotiation.
 - Responds to `NEW-ENVIRON` requests with a crafted `USER` payload.
@@ -16,9 +23,11 @@ It creates an interactive Moonlight session and injects a controlled `USER` valu
 - Optionally suppresses echoed command text until newline.
 
 ## Usage
+
 From the Moonlight console:
 
 ```text
+search CVE-2026-24061
 policy enable exploit_execution
 use exploit/linux/telnet/gnu_inetutils_telnetd_auth_bypass
 show options
@@ -26,6 +35,12 @@ set RHOST <ip-addr>
 set RPORT <port>
 set USER_PAYLOAD -f root
 run --yes
+```
+
+Search also works with the numeric CVE form:
+
+```text
+search 2026-24061
 ```
 
 If successful, Moonlight opens a session:
@@ -45,6 +60,7 @@ background
 ```
 
 ## Option Reference
+
 - `RHOST` (required): Target host or address.
 - `RPORT` (default: `23`): Target TELNET port.
 - `USER_PAYLOAD` (default: `-f root`): Value sent as the TELNET `USER` environment variable.
@@ -53,6 +69,7 @@ background
 - `SUPPRESS_ECHO` (default: `true`): Suppresses echoed command text until newline.
 
 ## Typical Operator Flow
+
 1. Enable exploit guardrail capability with `policy enable exploit_execution`.
 2. Select module with `use`.
 3. Set target options (`RHOST`, optionally `RPORT`).
@@ -63,30 +80,36 @@ background
 8. Use `background` to return to Moonlight prompt without killing the session.
 
 ## Policy Guardrails
+
 - Exploit modules are blocked by default until `exploit_execution` capability is enabled.
 - If the target is public or wide-scope, additional policy capabilities and confirmation prompts may apply.
 - `run --yes` skips interactive confirmation prompts for the current command.
 - Check current guardrail state with `policy`.
 
 ## Session Management
+
 - `sessions`: list all sessions.
 - `interact <session-id>`: attach to one session.
 - `sessions -k <session-id>`: close one session.
 - `sessions -K`: close all sessions.
 
 ## Expected Results
+
 On success:
+
 - `run` reports session creation.
 - `sessions` shows an `open` TELNET session for the target.
 - `interact` returns command output from the remote endpoint.
 
 On failure:
+
 - Option validation error if required values are missing.
 - Connection failure if target is unreachable or port is closed.
 - Session may close if target drops the socket during negotiation.
 - Policy denial with `ML-CLI-0004` if required capabilities are not enabled.
 
 ## Notes
+
 - Keep `USER_PAYLOAD` aligned with your intended test case.
 - `STRIP_ANSI` and `SUPPRESS_ECHO` improve readability for interactive use and can be disabled if raw output is needed.
 - Some labs expose a restricted command shell; in that case commands like `ls`/`touch` may return `unknown command` even when session access is valid.

--- a/modules/modules/src/catalog.rs
+++ b/modules/modules/src/catalog.rs
@@ -615,6 +615,21 @@ fn build_search_text(metadata: &ModuleMetadata) -> String {
         out.push(' ');
         out.push_str(&platform.to_ascii_lowercase());
     }
+    for reference in &metadata.references {
+        let kind = reference.kind.to_ascii_lowercase();
+        let value = reference.value.to_ascii_lowercase();
+        out.push(' ');
+        out.push_str(&kind);
+        out.push(' ');
+        out.push_str(&value);
+
+        if kind == "cve" {
+            if let Some(suffix) = value.strip_prefix("cve-") {
+                out.push(' ');
+                out.push_str(suffix);
+            }
+        }
+    }
     out
 }
 
@@ -1354,14 +1369,34 @@ mod tests {
     use super::*;
 
     fn write_manifest(path: &Path, name: &str, category: &str, tags: &[&str]) {
+        write_manifest_with_references(path, name, category, tags, &[]);
+    }
+
+    fn write_manifest_with_references(
+        path: &Path,
+        name: &str,
+        category: &str,
+        tags: &[&str],
+        references: &[(&str, &str)],
+    ) {
         let tags_json = tags
             .iter()
             .map(|t| format!("\"{}\"", t))
             .collect::<Vec<String>>()
             .join(",");
+        let references_json = references
+            .iter()
+            .map(|(kind, value)| format!("{{\"kind\":\"{}\",\"value\":\"{}\"}}", kind, value))
+            .collect::<Vec<String>>()
+            .join(",");
+        let references_field = if references.is_empty() {
+            String::new()
+        } else {
+            format!(",\n  \"references\": [{}]", references_json)
+        };
         let content = format!(
-            "{{\n  \"manifest_version\": 1,\n  \"module_api_version\": 1,\n  \"runtime\": \"builtin\",\n  \"name\": \"{}\",\n  \"description\": \"{}\",\n  \"category\": \"{}\",\n  \"rank\": \"normal\",\n  \"author\": \"me\",\n  \"platforms\": [\"cross\"],\n  \"tags\": [{}],\n  \"entrypoint\": \"module.rs\"\n}}",
-            name, name, category, tags_json
+            "{{\n  \"manifest_version\": 1,\n  \"module_api_version\": 1,\n  \"runtime\": \"builtin\",\n  \"name\": \"{}\",\n  \"description\": \"{}\",\n  \"category\": \"{}\",\n  \"rank\": \"normal\",\n  \"author\": \"me\",\n  \"platforms\": [\"cross\"],\n  \"tags\": [{}],\n  \"entrypoint\": \"module.rs\"{}\n}}",
+            name, name, category, tags_json, references_field
         );
         std::fs::write(path, content).expect("write manifest");
     }
@@ -1452,6 +1487,55 @@ mod tests {
             "error: {}",
             catalog.validation_errors()[0]
         );
+
+        std::fs::remove_dir_all(&root).ok();
+    }
+
+    #[test]
+    fn search_includes_cve_references_from_manifest() {
+        let root = std::env::temp_dir().join("moonlight_catalog_cve_search_test");
+        let _ = std::fs::remove_dir_all(&root);
+        std::fs::create_dir_all(&root).expect("create root");
+        let mod_dir = root.join("mod");
+        std::fs::create_dir_all(&mod_dir).expect("create mod");
+        write_manifest_with_references(
+            &mod_dir.join("module.json"),
+            "exploit/linux/telnet/gnu_inetutils_telnetd_auth_bypass",
+            "exploit",
+            &["telnet"],
+            &[("cve", "CVE-2026-24061")],
+        );
+
+        let cache_dir = root.join(".cache");
+        let catalog = ModuleCatalog::load(&root, &cache_dir).expect("load catalog");
+        assert_eq!(catalog.len(), 1);
+        let record = catalog
+            .get_by_name("exploit/linux/telnet/gnu_inetutils_telnetd_auth_bypass")
+            .expect("module present");
+        assert!(
+            record.search_text.contains("cve-2026-24061"),
+            "search text did not include CVE reference: {}",
+            record.search_text
+        );
+
+        let mut query = SearchQuery::new();
+        query.term = Some("CVE-2026-24061".to_string());
+        let cve_results = catalog.search(&query);
+        assert_eq!(cve_results.len(), 1);
+        assert_eq!(
+            cve_results[0].metadata.name,
+            "exploit/linux/telnet/gnu_inetutils_telnetd_auth_bypass"
+        );
+
+        let mut number_only_query = SearchQuery::new();
+        number_only_query.term = Some("2026-24061".to_string());
+        let number_results = catalog.search(&number_only_query);
+        assert_eq!(number_results.len(), 1);
+
+        let mut kind_query = SearchQuery::new();
+        kind_query.term = Some("cve".to_string());
+        let kind_results = catalog.search(&kind_query);
+        assert_eq!(kind_results.len(), 1);
 
         std::fs::remove_dir_all(&root).ok();
     }

--- a/modules/modules/src/exploit/linux/telnet/gnu_inetutils_telnetd_auth_bypass.rs
+++ b/modules/modules/src/exploit/linux/telnet/gnu_inetutils_telnetd_auth_bypass.rs
@@ -133,6 +133,7 @@ fn factory_metadata() -> ModuleMetadata {
     .with_tag("new-environ")
     .with_tag("session")
     .with_platform("linux")
+    .with_reference("cve", "CVE-2026-24061")
     .with_entrypoint("module.rs")
 }
 
@@ -354,6 +355,16 @@ mod tests {
     use super::*;
     use std::thread;
     use std::time::Duration;
+
+    #[test]
+    fn module_metadata_contains_cve_reference() {
+        let metadata = factory_metadata();
+        let has_cve = metadata.references.iter().any(|reference| {
+            reference.kind.eq_ignore_ascii_case("cve")
+                && reference.value.eq_ignore_ascii_case("CVE-2026-24061")
+        });
+        assert!(has_cve, "expected CVE-2026-24061 reference in metadata");
+    }
 
     #[test]
     fn module_returns_interactive_session_and_injects_payload() {

--- a/registry/exploit/linux/telnet/gnu_inetutils_telnetd_auth_bypass/module.json
+++ b/registry/exploit/linux/telnet/gnu_inetutils_telnetd_auth_bypass/module.json
@@ -18,5 +18,11 @@
     "gnu",
     "inetutils"
   ],
-  "entrypoint": "module.rs"
+  "entrypoint": "module.rs",
+  "references": [
+    {
+      "kind": "cve",
+      "value": "CVE-2026-24061"
+    }
+  ]
 }


### PR DESCRIPTION
## Summary
Adds CVE reference support to module discovery flow and wires `CVE-2026-24061` into the GNU inetutils telnetd auth bypass module so operators can find modules by CVE directly.

## Changes
- Added CVE metadata reference to built-in telnet exploit module:
  - `modules/modules/src/exploit/linux/telnet/gnu_inetutils_telnetd_auth_bypass.rs`
- Added CVE reference in registry manifest:
  - `registry/exploit/linux/telnet/gnu_inetutils_telnetd_auth_bypass/module.json`
- Extended catalog search indexing to include module references (`kind` + `value`), including numeric CVE suffix support:
  - `modules/modules/src/catalog.rs`
- Updated module documentation with CVE section and CVE search usage examples:
  - `docs/modules/exploit/linux/telnet/gnu_inetutils_telnetd_auth_bypass.md`

## Search Behavior
After this change, module search matches:
- `search CVE-2026-24061`
- `search 2026-24061`
- `search cve` (broader reference match)

## Tests
- Added/updated tests in `modules/modules/src/catalog.rs` for CVE-based search.
- Added metadata test in telnet module verifying CVE reference presence.
- Validation run: `cargo test -p modules` (passing).