### PR TITLE
Added deterministic Campaign/Objective control layer with replay-safe orchestration, policy guardrails, and operator docs

### DIFF
--- a/core/core/src/campaign.rs
+++ b/core/core/src/campaign.rs
@@ -1,0 +1,1215 @@
+use std::collections::{BTreeMap, BTreeSet};
+use std::fmt;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum CampaignModelError {
+    InvalidField {
+        field: &'static str,
+        reason: &'static str,
+    },
+    InvalidTransition {
+        entity: &'static str,
+        from: &'static str,
+        to: &'static str,
+    },
+}
+
+impl fmt::Display for CampaignModelError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            CampaignModelError::InvalidField { field, reason } => {
+                write!(f, "invalid field {field}: {reason}")
+            }
+            CampaignModelError::InvalidTransition { entity, from, to } => {
+                write!(f, "invalid {entity} transition: {from} -> {to}")
+            }
+        }
+    }
+}
+
+impl std::error::Error for CampaignModelError {}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub struct Uuid(String);
+
+impl Uuid {
+    pub fn parse(input: &str) -> Result<Self, CampaignModelError> {
+        let raw = input.trim();
+        if !is_valid_uuid(raw) {
+            return Err(CampaignModelError::InvalidField {
+                field: "uuid",
+                reason: "must be canonical RFC-4122 style UUID",
+            });
+        }
+        Ok(Self(raw.to_ascii_lowercase()))
+    }
+
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub struct CampaignId(Uuid);
+
+impl CampaignId {
+    pub fn parse(input: &str) -> Result<Self, CampaignModelError> {
+        Ok(Self(Uuid::parse(input)?))
+    }
+
+    pub fn as_str(&self) -> &str {
+        self.0.as_str()
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub struct ObjectiveId(Uuid);
+
+impl ObjectiveId {
+    pub fn parse(input: &str) -> Result<Self, CampaignModelError> {
+        Ok(Self(Uuid::parse(input)?))
+    }
+
+    pub fn as_str(&self) -> &str {
+        self.0.as_str()
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum CampaignStatus {
+    Active,
+    Paused,
+    Completed,
+    Failed,
+}
+
+impl CampaignStatus {
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            CampaignStatus::Active => "active",
+            CampaignStatus::Paused => "paused",
+            CampaignStatus::Completed => "completed",
+            CampaignStatus::Failed => "failed",
+        }
+    }
+
+    pub const fn can_transition_to(self, next: Self) -> bool {
+        match (self, next) {
+            (CampaignStatus::Active, CampaignStatus::Paused)
+            | (CampaignStatus::Active, CampaignStatus::Completed)
+            | (CampaignStatus::Active, CampaignStatus::Failed)
+            | (CampaignStatus::Paused, CampaignStatus::Active)
+            | (CampaignStatus::Paused, CampaignStatus::Completed)
+            | (CampaignStatus::Paused, CampaignStatus::Failed) => true,
+            _ => false,
+        }
+    }
+
+    pub const fn is_terminal(self) -> bool {
+        matches!(self, CampaignStatus::Completed | CampaignStatus::Failed)
+    }
+}
+
+pub const CAMPAIGN_ALLOWED_TRANSITIONS: &[(CampaignStatus, CampaignStatus)] = &[
+    (CampaignStatus::Active, CampaignStatus::Paused),
+    (CampaignStatus::Active, CampaignStatus::Completed),
+    (CampaignStatus::Active, CampaignStatus::Failed),
+    (CampaignStatus::Paused, CampaignStatus::Active),
+    (CampaignStatus::Paused, CampaignStatus::Completed),
+    (CampaignStatus::Paused, CampaignStatus::Failed),
+];
+
+pub const CAMPAIGN_FORBIDDEN_TRANSITIONS: &[(CampaignStatus, CampaignStatus)] = &[
+    (CampaignStatus::Active, CampaignStatus::Active),
+    (CampaignStatus::Paused, CampaignStatus::Paused),
+    (CampaignStatus::Completed, CampaignStatus::Active),
+    (CampaignStatus::Completed, CampaignStatus::Paused),
+    (CampaignStatus::Completed, CampaignStatus::Completed),
+    (CampaignStatus::Completed, CampaignStatus::Failed),
+    (CampaignStatus::Failed, CampaignStatus::Active),
+    (CampaignStatus::Failed, CampaignStatus::Paused),
+    (CampaignStatus::Failed, CampaignStatus::Completed),
+    (CampaignStatus::Failed, CampaignStatus::Failed),
+];
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum ObjectiveStatus {
+    Pending,
+    Eligible,
+    InProgress,
+    Achieved,
+    Failed,
+}
+
+impl ObjectiveStatus {
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            ObjectiveStatus::Pending => "pending",
+            ObjectiveStatus::Eligible => "eligible",
+            ObjectiveStatus::InProgress => "in_progress",
+            ObjectiveStatus::Achieved => "achieved",
+            ObjectiveStatus::Failed => "failed",
+        }
+    }
+
+    pub const fn can_transition_to(self, next: Self) -> bool {
+        match (self, next) {
+            (ObjectiveStatus::Pending, ObjectiveStatus::Eligible)
+            | (ObjectiveStatus::Eligible, ObjectiveStatus::InProgress)
+            | (ObjectiveStatus::InProgress, ObjectiveStatus::Achieved)
+            | (ObjectiveStatus::InProgress, ObjectiveStatus::Failed) => true,
+            _ => false,
+        }
+    }
+
+    pub const fn is_terminal(self) -> bool {
+        matches!(self, ObjectiveStatus::Achieved | ObjectiveStatus::Failed)
+    }
+}
+
+pub const OBJECTIVE_ALLOWED_TRANSITIONS: &[(ObjectiveStatus, ObjectiveStatus)] = &[
+    (ObjectiveStatus::Pending, ObjectiveStatus::Eligible),
+    (ObjectiveStatus::Eligible, ObjectiveStatus::InProgress),
+    (ObjectiveStatus::InProgress, ObjectiveStatus::Achieved),
+    (ObjectiveStatus::InProgress, ObjectiveStatus::Failed),
+];
+
+pub const OBJECTIVE_FORBIDDEN_TRANSITIONS: &[(ObjectiveStatus, ObjectiveStatus)] = &[
+    (ObjectiveStatus::Pending, ObjectiveStatus::Pending),
+    (ObjectiveStatus::Pending, ObjectiveStatus::InProgress),
+    (ObjectiveStatus::Pending, ObjectiveStatus::Achieved),
+    (ObjectiveStatus::Pending, ObjectiveStatus::Failed),
+    (ObjectiveStatus::Eligible, ObjectiveStatus::Pending),
+    (ObjectiveStatus::Eligible, ObjectiveStatus::Eligible),
+    (ObjectiveStatus::Eligible, ObjectiveStatus::Achieved),
+    (ObjectiveStatus::Eligible, ObjectiveStatus::Failed),
+    (ObjectiveStatus::InProgress, ObjectiveStatus::Pending),
+    (ObjectiveStatus::InProgress, ObjectiveStatus::Eligible),
+    (ObjectiveStatus::InProgress, ObjectiveStatus::InProgress),
+    (ObjectiveStatus::Achieved, ObjectiveStatus::Pending),
+    (ObjectiveStatus::Achieved, ObjectiveStatus::Eligible),
+    (ObjectiveStatus::Achieved, ObjectiveStatus::InProgress),
+    (ObjectiveStatus::Achieved, ObjectiveStatus::Achieved),
+    (ObjectiveStatus::Achieved, ObjectiveStatus::Failed),
+    (ObjectiveStatus::Failed, ObjectiveStatus::Pending),
+    (ObjectiveStatus::Failed, ObjectiveStatus::Eligible),
+    (ObjectiveStatus::Failed, ObjectiveStatus::InProgress),
+    (ObjectiveStatus::Failed, ObjectiveStatus::Achieved),
+    (ObjectiveStatus::Failed, ObjectiveStatus::Failed),
+];
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum RiskLevel {
+    Low,
+    Medium,
+    High,
+}
+
+impl RiskLevel {
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            RiskLevel::Low => "low",
+            RiskLevel::Medium => "medium",
+            RiskLevel::High => "high",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum SessionPrivilegeLevel {
+    User,
+    Elevated,
+    Root,
+}
+
+impl SessionPrivilegeLevel {
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            SessionPrivilegeLevel::User => "user",
+            SessionPrivilegeLevel::Elevated => "elevated",
+            SessionPrivilegeLevel::Root => "root",
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum MetadataValue {
+    Null,
+    Bool(bool),
+    Integer(i64),
+    FloatBits(u64),
+    Text(String),
+    Array(Vec<MetadataValue>),
+    Object(BTreeMap<String, MetadataValue>),
+}
+
+impl Eq for MetadataValue {}
+
+impl MetadataValue {
+    pub fn stable_encoding(&self) -> String {
+        match self {
+            MetadataValue::Null => "null".to_string(),
+            MetadataValue::Bool(value) => {
+                if *value {
+                    "bool:true".to_string()
+                } else {
+                    "bool:false".to_string()
+                }
+            }
+            MetadataValue::Integer(value) => format!("int:{value}"),
+            MetadataValue::FloatBits(bits) => format!("float:{bits}"),
+            MetadataValue::Text(value) => format!("text:{}", escape_canonical(value)),
+            MetadataValue::Array(values) => {
+                let joined = values
+                    .iter()
+                    .map(|v| v.stable_encoding())
+                    .collect::<Vec<_>>()
+                    .join(",");
+                format!("array:[{joined}]")
+            }
+            MetadataValue::Object(map) => {
+                let joined = map
+                    .iter()
+                    .map(|(k, v)| format!("{}={}", escape_canonical(k), v.stable_encoding()))
+                    .collect::<Vec<_>>()
+                    .join(",");
+                format!("object:{{{joined}}}")
+            }
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Predicate {
+    FindingExists { finding_type: String },
+    SessionPrivilege { level: SessionPrivilegeLevel },
+    ArtifactTagMatch { tag: String },
+    RunSucceeded { module_name: String },
+    CustomMetadataMatch { key: String, value: MetadataValue },
+}
+
+impl Predicate {
+    pub fn stable_encoding(&self) -> String {
+        match self {
+            Predicate::FindingExists { finding_type } => {
+                format!("finding_exists:{}", normalize_token(finding_type))
+            }
+            Predicate::SessionPrivilege { level } => {
+                format!("session_privilege:{}", level.as_str())
+            }
+            Predicate::ArtifactTagMatch { tag } => {
+                format!("artifact_tag_match:{}", normalize_token(tag))
+            }
+            Predicate::RunSucceeded { module_name } => {
+                format!("run_succeeded:{}", normalize_token(module_name))
+            }
+            Predicate::CustomMetadataMatch { key, value } => {
+                format!(
+                    "custom_metadata_match:{}={}",
+                    normalize_token(key),
+                    value.stable_encoding()
+                )
+            }
+        }
+    }
+
+    pub fn evaluate(&self, view: &PredicateEvaluationView) -> bool {
+        match self {
+            Predicate::FindingExists { finding_type } => {
+                view.finding_types.contains(&normalize_token(finding_type))
+            }
+            Predicate::SessionPrivilege { level } => view.session_privilege == Some(*level),
+            Predicate::ArtifactTagMatch { tag } => {
+                view.artifact_tags.contains(&normalize_token(tag))
+            }
+            Predicate::RunSucceeded { module_name } => view
+                .successful_run_modules
+                .contains(&normalize_token(module_name)),
+            Predicate::CustomMetadataMatch { key, value } => view
+                .custom_metadata
+                .get(&normalize_token(key))
+                .map(|actual| actual == value)
+                .unwrap_or(false),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ObjectiveEvaluationResult {
+    pub prerequisites_satisfied: bool,
+    pub success_criteria_satisfied: bool,
+    pub failure_criteria_satisfied: bool,
+    pub next_status: Option<ObjectiveStatus>,
+}
+
+impl ObjectiveEvaluationResult {
+    pub const fn no_transition(
+        prerequisites_satisfied: bool,
+        success_criteria_satisfied: bool,
+        failure_criteria_satisfied: bool,
+    ) -> Self {
+        Self {
+            prerequisites_satisfied,
+            success_criteria_satisfied,
+            failure_criteria_satisfied,
+            next_status: None,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PredicateEvaluationView {
+    pub finding_types: BTreeSet<String>,
+    pub session_privilege: Option<SessionPrivilegeLevel>,
+    pub artifact_tags: BTreeSet<String>,
+    pub successful_run_modules: BTreeSet<String>,
+    pub custom_metadata: BTreeMap<String, MetadataValue>,
+}
+
+impl PredicateEvaluationView {
+    pub fn new() -> Self {
+        Self {
+            finding_types: BTreeSet::new(),
+            session_privilege: None,
+            artifact_tags: BTreeSet::new(),
+            successful_run_modules: BTreeSet::new(),
+            custom_metadata: BTreeMap::new(),
+        }
+    }
+
+    pub fn with_finding_type(mut self, finding_type: &str) -> Self {
+        self.finding_types.insert(normalize_token(finding_type));
+        self
+    }
+
+    pub fn with_session_privilege(mut self, level: SessionPrivilegeLevel) -> Self {
+        self.session_privilege = Some(level);
+        self
+    }
+
+    pub fn with_artifact_tag(mut self, tag: &str) -> Self {
+        self.artifact_tags.insert(normalize_token(tag));
+        self
+    }
+
+    pub fn with_successful_run(mut self, module_name: &str) -> Self {
+        self.successful_run_modules
+            .insert(normalize_token(module_name));
+        self
+    }
+
+    pub fn with_custom_metadata(mut self, key: &str, value: MetadataValue) -> Self {
+        self.custom_metadata.insert(normalize_token(key), value);
+        self
+    }
+}
+
+impl Default for PredicateEvaluationView {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Campaign {
+    pub id: CampaignId,
+    pub name: String,
+    pub description: String,
+    pub created_at: u64,
+    pub status: CampaignStatus,
+    pub objective_ids: Vec<ObjectiveId>,
+    pub metadata: Option<BTreeMap<String, MetadataValue>>,
+}
+
+impl Campaign {
+    pub fn new_at(
+        id: CampaignId,
+        name: &str,
+        description: &str,
+        created_at: u64,
+        metadata: Option<BTreeMap<String, MetadataValue>>,
+    ) -> Result<Self, CampaignModelError> {
+        ensure_non_empty(name, "campaign.name")?;
+        Ok(Self {
+            id,
+            name: name.trim().to_string(),
+            description: description.trim().to_string(),
+            created_at,
+            status: CampaignStatus::Active,
+            objective_ids: Vec::new(),
+            metadata,
+        })
+    }
+
+    pub fn transition_status(&mut self, next: CampaignStatus) -> Result<(), CampaignModelError> {
+        if self.status == next {
+            return Err(CampaignModelError::InvalidTransition {
+                entity: "campaign",
+                from: self.status.as_str(),
+                to: next.as_str(),
+            });
+        }
+        if !self.status.can_transition_to(next) {
+            return Err(CampaignModelError::InvalidTransition {
+                entity: "campaign",
+                from: self.status.as_str(),
+                to: next.as_str(),
+            });
+        }
+        self.status = next;
+        Ok(())
+    }
+
+    pub fn add_objective(&mut self, objective_id: ObjectiveId) {
+        if self.objective_ids.contains(&objective_id) {
+            return;
+        }
+        self.objective_ids.push(objective_id);
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Objective {
+    pub id: ObjectiveId,
+    pub campaign_id: CampaignId,
+    pub name: String,
+    pub description: String,
+    pub status: ObjectiveStatus,
+    pub prerequisites: Vec<ObjectiveId>,
+    pub success_criteria: Vec<Predicate>,
+    pub failure_criteria: Vec<Predicate>,
+    pub risk_level: RiskLevel,
+    pub noise_budget: Option<u32>,
+    pub created_at: u64,
+    pub updated_at: u64,
+}
+
+impl Objective {
+    #[allow(clippy::too_many_arguments)]
+    pub fn new_at(
+        id: ObjectiveId,
+        campaign_id: CampaignId,
+        name: &str,
+        description: &str,
+        prerequisites: Vec<ObjectiveId>,
+        success_criteria: Vec<Predicate>,
+        failure_criteria: Vec<Predicate>,
+        risk_level: RiskLevel,
+        noise_budget: Option<u32>,
+        now: u64,
+    ) -> Result<Self, CampaignModelError> {
+        ensure_non_empty(name, "objective.name")?;
+        if success_criteria.is_empty() {
+            return Err(CampaignModelError::InvalidField {
+                field: "objective.success_criteria",
+                reason: "must contain at least one predicate",
+            });
+        }
+
+        if noise_budget == Some(0) {
+            return Err(CampaignModelError::InvalidField {
+                field: "objective.noise_budget",
+                reason: "must be greater than zero when provided",
+            });
+        }
+
+        let prerequisites = dedupe_objective_ids(prerequisites);
+        if prerequisites.contains(&id) {
+            return Err(CampaignModelError::InvalidField {
+                field: "objective.prerequisites",
+                reason: "cannot include objective id itself",
+            });
+        }
+
+        Ok(Self {
+            id,
+            campaign_id,
+            name: name.trim().to_string(),
+            description: description.trim().to_string(),
+            status: ObjectiveStatus::Pending,
+            prerequisites,
+            success_criteria,
+            failure_criteria,
+            risk_level,
+            noise_budget,
+            created_at: now,
+            updated_at: now,
+        })
+    }
+
+    pub fn prerequisites_satisfied(&self, achieved: &BTreeSet<ObjectiveId>) -> bool {
+        self.prerequisites
+            .iter()
+            .all(|prereq| achieved.contains(prereq))
+    }
+
+    pub fn success_criteria_satisfied(&self, view: &PredicateEvaluationView) -> bool {
+        self.success_criteria
+            .iter()
+            .all(|predicate| predicate.evaluate(view))
+    }
+
+    pub fn failure_criteria_satisfied(&self, view: &PredicateEvaluationView) -> bool {
+        self.failure_criteria
+            .iter()
+            .any(|predicate| predicate.evaluate(view))
+    }
+
+    pub fn evaluate_transition(
+        &self,
+        prerequisites_satisfied: bool,
+        view: &PredicateEvaluationView,
+    ) -> ObjectiveEvaluationResult {
+        let success_criteria_satisfied = self.success_criteria_satisfied(view);
+        let failure_criteria_satisfied = self.failure_criteria_satisfied(view);
+
+        let next_status = match self.status {
+            ObjectiveStatus::Pending if prerequisites_satisfied => Some(ObjectiveStatus::Eligible),
+            ObjectiveStatus::InProgress if failure_criteria_satisfied => {
+                Some(ObjectiveStatus::Failed)
+            }
+            ObjectiveStatus::InProgress if success_criteria_satisfied => {
+                Some(ObjectiveStatus::Achieved)
+            }
+            _ => None,
+        };
+
+        ObjectiveEvaluationResult {
+            prerequisites_satisfied,
+            success_criteria_satisfied,
+            failure_criteria_satisfied,
+            next_status,
+        }
+    }
+
+    pub fn transition_to_eligible(
+        &mut self,
+        prerequisites_satisfied: bool,
+        now: u64,
+    ) -> Result<(), CampaignModelError> {
+        if !prerequisites_satisfied {
+            return Err(CampaignModelError::InvalidField {
+                field: "objective.prerequisites",
+                reason: "all prerequisites must be achieved before eligibility",
+            });
+        }
+        self.transition_status(ObjectiveStatus::Eligible, now)
+    }
+
+    pub fn transition_to_in_progress(&mut self, now: u64) -> Result<(), CampaignModelError> {
+        self.transition_status(ObjectiveStatus::InProgress, now)
+    }
+
+    pub fn transition_to_achieved(
+        &mut self,
+        success_criteria_satisfied: bool,
+        now: u64,
+    ) -> Result<(), CampaignModelError> {
+        if !success_criteria_satisfied {
+            return Err(CampaignModelError::InvalidField {
+                field: "objective.success_criteria",
+                reason: "all success criteria must be satisfied",
+            });
+        }
+        self.transition_status(ObjectiveStatus::Achieved, now)
+    }
+
+    pub fn transition_to_failed(
+        &mut self,
+        failure_criteria_satisfied: bool,
+        now: u64,
+    ) -> Result<(), CampaignModelError> {
+        if !failure_criteria_satisfied {
+            return Err(CampaignModelError::InvalidField {
+                field: "objective.failure_criteria",
+                reason: "at least one failure criterion must be satisfied",
+            });
+        }
+        self.transition_status(ObjectiveStatus::Failed, now)
+    }
+
+    pub fn transition_status(
+        &mut self,
+        next: ObjectiveStatus,
+        now: u64,
+    ) -> Result<(), CampaignModelError> {
+        if self.status == next {
+            return Err(CampaignModelError::InvalidTransition {
+                entity: "objective",
+                from: self.status.as_str(),
+                to: next.as_str(),
+            });
+        }
+        if !self.status.can_transition_to(next) {
+            return Err(CampaignModelError::InvalidTransition {
+                entity: "objective",
+                from: self.status.as_str(),
+                to: next.as_str(),
+            });
+        }
+        self.status = next;
+        self.updated_at = now;
+        Ok(())
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum CampaignInvariant {
+    CampaignNameRequired,
+    ObjectiveNameRequired,
+    ObjectiveSuccessCriteriaRequired,
+    ObjectivePrerequisitesNoSelfReference,
+    ObjectiveNoiseBudgetPositiveWhenPresent,
+    CampaignStatusStrictTransitions,
+    ObjectiveStatusStrictTransitions,
+    ObjectiveTerminalStatesNoOutgoing,
+    ObjectiveNoSilentStatusChanges,
+    CampaignNoSilentStatusChanges,
+    ObjectiveEvaluationPureDeterministic,
+    ObjectiveEvaluationNoSideEffects,
+}
+
+impl CampaignInvariant {
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            CampaignInvariant::CampaignNameRequired => "campaign_name_required",
+            CampaignInvariant::ObjectiveNameRequired => "objective_name_required",
+            CampaignInvariant::ObjectiveSuccessCriteriaRequired => {
+                "objective_success_criteria_required"
+            }
+            CampaignInvariant::ObjectivePrerequisitesNoSelfReference => {
+                "objective_prerequisites_no_self_reference"
+            }
+            CampaignInvariant::ObjectiveNoiseBudgetPositiveWhenPresent => {
+                "objective_noise_budget_positive_when_present"
+            }
+            CampaignInvariant::CampaignStatusStrictTransitions => {
+                "campaign_status_strict_transitions"
+            }
+            CampaignInvariant::ObjectiveStatusStrictTransitions => {
+                "objective_status_strict_transitions"
+            }
+            CampaignInvariant::ObjectiveTerminalStatesNoOutgoing => {
+                "objective_terminal_states_no_outgoing"
+            }
+            CampaignInvariant::ObjectiveNoSilentStatusChanges => {
+                "objective_no_silent_status_changes"
+            }
+            CampaignInvariant::CampaignNoSilentStatusChanges => "campaign_no_silent_status_changes",
+            CampaignInvariant::ObjectiveEvaluationPureDeterministic => {
+                "objective_evaluation_pure_deterministic"
+            }
+            CampaignInvariant::ObjectiveEvaluationNoSideEffects => {
+                "objective_evaluation_no_side_effects"
+            }
+        }
+    }
+}
+
+pub const CAMPAIGN_INVARIANTS: &[CampaignInvariant] = &[
+    CampaignInvariant::CampaignNameRequired,
+    CampaignInvariant::ObjectiveNameRequired,
+    CampaignInvariant::ObjectiveSuccessCriteriaRequired,
+    CampaignInvariant::ObjectivePrerequisitesNoSelfReference,
+    CampaignInvariant::ObjectiveNoiseBudgetPositiveWhenPresent,
+    CampaignInvariant::CampaignStatusStrictTransitions,
+    CampaignInvariant::ObjectiveStatusStrictTransitions,
+    CampaignInvariant::ObjectiveTerminalStatesNoOutgoing,
+    CampaignInvariant::ObjectiveNoSilentStatusChanges,
+    CampaignInvariant::CampaignNoSilentStatusChanges,
+    CampaignInvariant::ObjectiveEvaluationPureDeterministic,
+    CampaignInvariant::ObjectiveEvaluationNoSideEffects,
+];
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum ReplayRule {
+    AppendOnlyEventLog,
+    DeterministicOrderingByEventSequence,
+    TransitionValidationBeforeProjectionApply,
+    ObjectiveEvaluationIsIdempotent,
+    ObjectiveEvaluationIsPure,
+    ObjectiveEvaluationHasNoSideEffects,
+    ObjectiveRebuildFromEventHistory,
+    ObjectiveStateAdvancesOnlyViaRecordedTransitionEvent,
+}
+
+impl ReplayRule {
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            ReplayRule::AppendOnlyEventLog => "append_only_event_log",
+            ReplayRule::DeterministicOrderingByEventSequence => {
+                "deterministic_ordering_by_event_sequence"
+            }
+            ReplayRule::TransitionValidationBeforeProjectionApply => {
+                "transition_validation_before_projection_apply"
+            }
+            ReplayRule::ObjectiveEvaluationIsIdempotent => "objective_evaluation_is_idempotent",
+            ReplayRule::ObjectiveEvaluationIsPure => "objective_evaluation_is_pure",
+            ReplayRule::ObjectiveEvaluationHasNoSideEffects => {
+                "objective_evaluation_has_no_side_effects"
+            }
+            ReplayRule::ObjectiveRebuildFromEventHistory => "objective_rebuild_from_event_history",
+            ReplayRule::ObjectiveStateAdvancesOnlyViaRecordedTransitionEvent => {
+                "objective_state_advances_only_via_recorded_transition_event"
+            }
+        }
+    }
+}
+
+pub const REPLAY_RULES: &[ReplayRule] = &[
+    ReplayRule::AppendOnlyEventLog,
+    ReplayRule::DeterministicOrderingByEventSequence,
+    ReplayRule::TransitionValidationBeforeProjectionApply,
+    ReplayRule::ObjectiveEvaluationIsIdempotent,
+    ReplayRule::ObjectiveEvaluationIsPure,
+    ReplayRule::ObjectiveEvaluationHasNoSideEffects,
+    ReplayRule::ObjectiveRebuildFromEventHistory,
+    ReplayRule::ObjectiveStateAdvancesOnlyViaRecordedTransitionEvent,
+];
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum ObjectiveReevaluationTrigger {
+    ArtifactCreated,
+    FindingCreated,
+    SessionStateChanged,
+    RunCompleted,
+    ReplayRecovery,
+    ManualRequest,
+}
+
+impl ObjectiveReevaluationTrigger {
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            ObjectiveReevaluationTrigger::ArtifactCreated => "artifact_created",
+            ObjectiveReevaluationTrigger::FindingCreated => "finding_created",
+            ObjectiveReevaluationTrigger::SessionStateChanged => "session_state_changed",
+            ObjectiveReevaluationTrigger::RunCompleted => "run_completed",
+            ObjectiveReevaluationTrigger::ReplayRecovery => "replay_recovery",
+            ObjectiveReevaluationTrigger::ManualRequest => "manual_request",
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum CampaignEventPayload {
+    CampaignCreated {
+        campaign_id: CampaignId,
+        name: String,
+    },
+    CampaignStatusChanged {
+        campaign_id: CampaignId,
+        from: CampaignStatus,
+        to: CampaignStatus,
+        reason: Option<String>,
+    },
+    ObjectiveCreated {
+        campaign_id: CampaignId,
+        objective_id: ObjectiveId,
+        name: String,
+        risk_level: RiskLevel,
+    },
+    ObjectivePrerequisiteLinked {
+        campaign_id: CampaignId,
+        objective_id: ObjectiveId,
+        prerequisite_id: ObjectiveId,
+    },
+    ObjectiveStatusChanged {
+        campaign_id: CampaignId,
+        objective_id: ObjectiveId,
+        from: ObjectiveStatus,
+        to: ObjectiveStatus,
+        reason: Option<String>,
+    },
+    ObjectiveEvaluated {
+        campaign_id: CampaignId,
+        objective_id: ObjectiveId,
+        trigger: ObjectiveReevaluationTrigger,
+        prerequisites_satisfied: bool,
+        success_criteria_satisfied: bool,
+        failure_criteria_satisfied: bool,
+        resulting_status: ObjectiveStatus,
+    },
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum CampaignEventType {
+    CampaignCreated,
+    CampaignStatusChanged,
+    ObjectiveCreated,
+    ObjectivePrerequisiteLinked,
+    ObjectiveStatusChanged,
+    ObjectiveEvaluated,
+}
+
+impl CampaignEventType {
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            CampaignEventType::CampaignCreated => "campaign_created",
+            CampaignEventType::CampaignStatusChanged => "campaign_status_changed",
+            CampaignEventType::ObjectiveCreated => "objective_created",
+            CampaignEventType::ObjectivePrerequisiteLinked => "objective_prerequisite_linked",
+            CampaignEventType::ObjectiveStatusChanged => "objective_status_changed",
+            CampaignEventType::ObjectiveEvaluated => "objective_evaluated",
+        }
+    }
+}
+
+pub const CAMPAIGN_EVENT_TAXONOMY: &[CampaignEventType] = &[
+    CampaignEventType::CampaignCreated,
+    CampaignEventType::CampaignStatusChanged,
+    CampaignEventType::ObjectiveCreated,
+    CampaignEventType::ObjectivePrerequisiteLinked,
+    CampaignEventType::ObjectiveStatusChanged,
+    CampaignEventType::ObjectiveEvaluated,
+];
+
+impl CampaignEventPayload {
+    pub const fn event_type(&self) -> CampaignEventType {
+        match self {
+            CampaignEventPayload::CampaignCreated { .. } => CampaignEventType::CampaignCreated,
+            CampaignEventPayload::CampaignStatusChanged { .. } => {
+                CampaignEventType::CampaignStatusChanged
+            }
+            CampaignEventPayload::ObjectiveCreated { .. } => CampaignEventType::ObjectiveCreated,
+            CampaignEventPayload::ObjectivePrerequisiteLinked { .. } => {
+                CampaignEventType::ObjectivePrerequisiteLinked
+            }
+            CampaignEventPayload::ObjectiveStatusChanged { .. } => {
+                CampaignEventType::ObjectiveStatusChanged
+            }
+            CampaignEventPayload::ObjectiveEvaluated { .. } => {
+                CampaignEventType::ObjectiveEvaluated
+            }
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CampaignEvent {
+    pub sequence: u64,
+    pub occurred_at: u64,
+    pub payload: CampaignEventPayload,
+}
+
+fn dedupe_objective_ids(ids: Vec<ObjectiveId>) -> Vec<ObjectiveId> {
+    let mut seen = BTreeSet::new();
+    let mut out = Vec::new();
+    for id in ids {
+        if seen.insert(id.clone()) {
+            out.push(id);
+        }
+    }
+    out
+}
+
+fn ensure_non_empty(value: &str, field: &'static str) -> Result<(), CampaignModelError> {
+    if value.trim().is_empty() {
+        return Err(CampaignModelError::InvalidField {
+            field,
+            reason: "cannot be empty",
+        });
+    }
+    Ok(())
+}
+
+fn normalize_token(value: &str) -> String {
+    value.trim().to_ascii_lowercase()
+}
+
+fn escape_canonical(value: &str) -> String {
+    value
+        .replace('\\', "\\\\")
+        .replace(':', "\\:")
+        .replace(',', "\\,")
+        .replace('=', "\\=")
+}
+
+fn is_valid_uuid(value: &str) -> bool {
+    if value.len() != 36 {
+        return false;
+    }
+    for (idx, byte) in value.as_bytes().iter().copied().enumerate() {
+        match idx {
+            8 | 13 | 18 | 23 => {
+                if byte != b'-' {
+                    return false;
+                }
+            }
+            _ => {
+                if !byte.is_ascii_hexdigit() {
+                    return false;
+                }
+            }
+        }
+    }
+    true
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn campaign_id(seed: &str) -> CampaignId {
+        CampaignId::parse(seed).expect("campaign id")
+    }
+
+    fn objective_id(seed: &str) -> ObjectiveId {
+        ObjectiveId::parse(seed).expect("objective id")
+    }
+
+    #[test]
+    fn uuid_parser_enforces_canonical_shape() {
+        assert!(CampaignId::parse("de305d54-75b4-431b-adb2-eb6b9e546014").is_ok());
+        assert!(CampaignId::parse("DE305D54-75B4-431B-ADB2-EB6B9E546014").is_ok());
+        assert!(CampaignId::parse("de305d5475b4431badb2eb6b9e546014").is_err());
+        assert!(CampaignId::parse("not-a-uuid").is_err());
+    }
+
+    #[test]
+    fn campaign_transition_matrix_is_strict_and_unambiguous() {
+        let states = [
+            CampaignStatus::Active,
+            CampaignStatus::Paused,
+            CampaignStatus::Completed,
+            CampaignStatus::Failed,
+        ];
+        for from in states {
+            for to in states {
+                let expected = CAMPAIGN_ALLOWED_TRANSITIONS
+                    .iter()
+                    .any(|(f, t)| *f == from && *t == to);
+                assert_eq!(from.can_transition_to(to), expected);
+
+                let forbidden = CAMPAIGN_FORBIDDEN_TRANSITIONS
+                    .iter()
+                    .any(|(f, t)| *f == from && *t == to);
+                assert_ne!(
+                    expected, forbidden,
+                    "transition cannot be both allowed and forbidden"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn objective_transition_matrix_is_strict_and_unambiguous() {
+        let states = [
+            ObjectiveStatus::Pending,
+            ObjectiveStatus::Eligible,
+            ObjectiveStatus::InProgress,
+            ObjectiveStatus::Achieved,
+            ObjectiveStatus::Failed,
+        ];
+        for from in states {
+            for to in states {
+                let expected = OBJECTIVE_ALLOWED_TRANSITIONS
+                    .iter()
+                    .any(|(f, t)| *f == from && *t == to);
+                assert_eq!(from.can_transition_to(to), expected);
+
+                let forbidden = OBJECTIVE_FORBIDDEN_TRANSITIONS
+                    .iter()
+                    .any(|(f, t)| *f == from && *t == to);
+                assert_ne!(
+                    expected, forbidden,
+                    "transition cannot be both allowed and forbidden"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn no_op_transitions_are_rejected() {
+        let mut campaign = Campaign::new_at(
+            campaign_id("de305d54-75b4-431b-adb2-eb6b9e546014"),
+            "Engagement",
+            "phase 0",
+            42,
+            None,
+        )
+        .expect("campaign");
+        assert!(campaign.transition_status(CampaignStatus::Active).is_err());
+
+        let mut objective = Objective::new_at(
+            objective_id("7f5f5d5c-f9a9-42dc-a0ef-3d96f5565de8"),
+            campaign.id.clone(),
+            "Objective A",
+            "test no-op",
+            vec![],
+            vec![Predicate::FindingExists {
+                finding_type: "credential".to_string(),
+            }],
+            vec![],
+            RiskLevel::Low,
+            None,
+            42,
+        )
+        .expect("objective");
+        assert!(objective
+            .transition_status(ObjectiveStatus::Pending, 43)
+            .is_err());
+    }
+
+    #[test]
+    fn objective_validates_prerequisite_and_criteria_invariants() {
+        let objective = Objective::new_at(
+            objective_id("0f8fad5b-d9cb-469f-a165-70867728950e"),
+            campaign_id("de305d54-75b4-431b-adb2-eb6b9e546014"),
+            "Gain foothold",
+            "Get first session",
+            vec![objective_id("f47ac10b-58cc-4372-a567-0e02b2c3d479")],
+            vec![Predicate::FindingExists {
+                finding_type: "credential".to_string(),
+            }],
+            vec![],
+            RiskLevel::Medium,
+            Some(100),
+            100,
+        )
+        .expect("objective");
+
+        assert_eq!(objective.status, ObjectiveStatus::Pending);
+        assert_eq!(objective.prerequisites.len(), 1);
+
+        let err = Objective::new_at(
+            objective_id("f47ac10b-58cc-4372-a567-0e02b2c3d479"),
+            campaign_id("de305d54-75b4-431b-adb2-eb6b9e546014"),
+            "invalid",
+            "invalid",
+            vec![objective_id("f47ac10b-58cc-4372-a567-0e02b2c3d479")],
+            vec![Predicate::ArtifactTagMatch {
+                tag: "loot".to_string(),
+            }],
+            vec![],
+            RiskLevel::Low,
+            None,
+            100,
+        )
+        .expect_err("self prerequisite must fail");
+        assert!(
+            err.to_string().contains("objective.prerequisites"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn objective_enforces_transition_requirements() {
+        let mut objective = Objective::new_at(
+            objective_id("7f5f5d5c-f9a9-42dc-a0ef-3d96f5565de8"),
+            campaign_id("de305d54-75b4-431b-adb2-eb6b9e546014"),
+            "Escalate",
+            "Get root",
+            vec![],
+            vec![Predicate::SessionPrivilege {
+                level: SessionPrivilegeLevel::Root,
+            }],
+            vec![Predicate::FindingExists {
+                finding_type: "detection".to_string(),
+            }],
+            RiskLevel::High,
+            None,
+            10,
+        )
+        .expect("objective");
+
+        assert!(objective.transition_to_eligible(false, 11).is_err());
+        objective
+            .transition_to_eligible(true, 11)
+            .expect("eligible");
+        objective
+            .transition_to_in_progress(12)
+            .expect("in progress");
+        assert!(objective.transition_to_achieved(false, 13).is_err());
+        objective
+            .transition_to_achieved(true, 13)
+            .expect("achieved");
+        assert_eq!(objective.status, ObjectiveStatus::Achieved);
+        assert!(objective.transition_to_failed(true, 14).is_err());
+    }
+
+    #[test]
+    fn predicate_evaluation_is_pure_and_deterministic() {
+        let view = PredicateEvaluationView::new()
+            .with_finding_type("credential")
+            .with_session_privilege(SessionPrivilegeLevel::Root)
+            .with_artifact_tag("loot")
+            .with_successful_run("exploit/linux/example")
+            .with_custom_metadata("owner", MetadataValue::Text("redteam".to_string()));
+
+        let predicates = vec![
+            Predicate::FindingExists {
+                finding_type: "credential".to_string(),
+            },
+            Predicate::SessionPrivilege {
+                level: SessionPrivilegeLevel::Root,
+            },
+            Predicate::ArtifactTagMatch {
+                tag: "loot".to_string(),
+            },
+            Predicate::RunSucceeded {
+                module_name: "exploit/linux/example".to_string(),
+            },
+            Predicate::CustomMetadataMatch {
+                key: "owner".to_string(),
+                value: MetadataValue::Text("redteam".to_string()),
+            },
+        ];
+
+        for predicate in &predicates {
+            let first = predicate.evaluate(&view);
+            let second = predicate.evaluate(&view);
+            assert_eq!(first, second, "predicate must be deterministic");
+            assert!(first, "predicate should match prepared evaluation view");
+        }
+    }
+
+    #[test]
+    fn objective_evaluation_is_deterministic_and_side_effect_free() {
+        let objective = Objective::new_at(
+            objective_id("7f5f5d5c-f9a9-42dc-a0ef-3d96f5565de8"),
+            campaign_id("de305d54-75b4-431b-adb2-eb6b9e546014"),
+            "Escalate",
+            "Get root",
+            vec![],
+            vec![Predicate::SessionPrivilege {
+                level: SessionPrivilegeLevel::Root,
+            }],
+            vec![Predicate::FindingExists {
+                finding_type: "detection".to_string(),
+            }],
+            RiskLevel::High,
+            Some(10),
+            10,
+        )
+        .expect("objective");
+
+        let snapshot = objective.clone();
+        let view =
+            PredicateEvaluationView::new().with_session_privilege(SessionPrivilegeLevel::Root);
+        let first = objective.evaluate_transition(true, &view);
+        let second = objective.evaluate_transition(true, &view);
+        assert_eq!(first, second);
+        assert_eq!(objective, snapshot, "evaluation must not mutate objective");
+        assert_eq!(first.next_status, Some(ObjectiveStatus::Eligible));
+    }
+
+    #[test]
+    fn stable_encoding_is_repeatable() {
+        let predicate = Predicate::CustomMetadataMatch {
+            key: "risk_profile".to_string(),
+            value: MetadataValue::Object(BTreeMap::from([
+                ("noise".to_string(), MetadataValue::Integer(2)),
+                (
+                    "tags".to_string(),
+                    MetadataValue::Array(vec![
+                        MetadataValue::Text("stealth".to_string()),
+                        MetadataValue::Text("lateral".to_string()),
+                    ]),
+                ),
+            ])),
+        };
+        let a = predicate.stable_encoding();
+        let b = predicate.stable_encoding();
+        assert_eq!(a, b);
+    }
+}

--- a/core/core/src/campaign.rs
+++ b/core/core/src/campaign.rs
@@ -12,6 +12,12 @@ pub enum CampaignModelError {
         from: &'static str,
         to: &'static str,
     },
+    MissingObjective {
+        objective_id: ObjectiveId,
+    },
+    PrerequisiteCycle {
+        objective_id: ObjectiveId,
+    },
 }
 
 impl fmt::Display for CampaignModelError {
@@ -23,11 +29,36 @@ impl fmt::Display for CampaignModelError {
             CampaignModelError::InvalidTransition { entity, from, to } => {
                 write!(f, "invalid {entity} transition: {from} -> {to}")
             }
+            CampaignModelError::MissingObjective { objective_id } => {
+                write!(
+                    f,
+                    "objective reference does not exist in campaign graph: {}",
+                    objective_id.as_str()
+                )
+            }
+            CampaignModelError::PrerequisiteCycle { objective_id } => {
+                write!(
+                    f,
+                    "objective prerequisite cycle detected near objective {}",
+                    objective_id.as_str()
+                )
+            }
         }
     }
 }
 
 impl std::error::Error for CampaignModelError {}
+
+impl CampaignModelError {
+    pub const fn code(&self) -> &'static str {
+        match self {
+            CampaignModelError::InvalidField { .. } => "ML-CAMP-0001",
+            CampaignModelError::InvalidTransition { .. } => "ML-CAMP-0002",
+            CampaignModelError::MissingObjective { .. } => "ML-CAMP-0003",
+            CampaignModelError::PrerequisiteCycle { .. } => "ML-CAMP-0004",
+        }
+    }
+}
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub struct Uuid(String);
@@ -891,6 +922,106 @@ pub struct CampaignEvent {
     pub payload: CampaignEventPayload,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum VisitState {
+    Visiting,
+    Visited,
+}
+
+pub fn validate_prerequisite_graph(objectives: &[Objective]) -> Result<(), CampaignModelError> {
+    let mut objective_map = BTreeMap::new();
+    for objective in objectives {
+        let previous = objective_map.insert(objective.id.clone(), objective);
+        if previous.is_some() {
+            return Err(CampaignModelError::InvalidField {
+                field: "objective.id",
+                reason: "duplicate objective id in campaign graph",
+            });
+        }
+    }
+
+    for objective in objectives {
+        for prerequisite in &objective.prerequisites {
+            if !objective_map.contains_key(prerequisite) {
+                return Err(CampaignModelError::MissingObjective {
+                    objective_id: prerequisite.clone(),
+                });
+            }
+        }
+    }
+
+    let mut visit_states = BTreeMap::<ObjectiveId, VisitState>::new();
+    for objective_id in objective_map.keys() {
+        if visit_states.contains_key(objective_id) {
+            continue;
+        }
+        detect_prerequisite_cycle(objective_id, &objective_map, &mut visit_states)?;
+    }
+    Ok(())
+}
+
+pub fn validate_prerequisite_link(
+    objectives: &[Objective],
+    objective_id: &ObjectiveId,
+    prerequisite_id: &ObjectiveId,
+) -> Result<(), CampaignModelError> {
+    let mut next_objectives = objectives.to_vec();
+    let mut found = false;
+    for objective in &mut next_objectives {
+        if &objective.id == objective_id {
+            found = true;
+            if &objective.id == prerequisite_id {
+                return Err(CampaignModelError::InvalidField {
+                    field: "objective.prerequisites",
+                    reason: "cannot include objective id itself",
+                });
+            }
+            if !objective.prerequisites.contains(prerequisite_id) {
+                objective.prerequisites.push(prerequisite_id.clone());
+            }
+            break;
+        }
+    }
+
+    if !found {
+        return Err(CampaignModelError::MissingObjective {
+            objective_id: objective_id.clone(),
+        });
+    }
+
+    validate_prerequisite_graph(&next_objectives)
+}
+
+fn detect_prerequisite_cycle(
+    objective_id: &ObjectiveId,
+    objective_map: &BTreeMap<ObjectiveId, &Objective>,
+    visit_states: &mut BTreeMap<ObjectiveId, VisitState>,
+) -> Result<(), CampaignModelError> {
+    visit_states.insert(objective_id.clone(), VisitState::Visiting);
+
+    let objective =
+        objective_map
+            .get(objective_id)
+            .ok_or_else(|| CampaignModelError::MissingObjective {
+                objective_id: objective_id.clone(),
+            })?;
+
+    for prerequisite_id in &objective.prerequisites {
+        match visit_states.get(prerequisite_id).copied() {
+            Some(VisitState::Visiting) => {
+                return Err(CampaignModelError::PrerequisiteCycle {
+                    objective_id: objective_id.clone(),
+                });
+            }
+            Some(VisitState::Visited) => {}
+            None => detect_prerequisite_cycle(prerequisite_id, objective_map, visit_states)?,
+        }
+    }
+
+    visit_states.insert(objective_id.clone(), VisitState::Visited);
+    Ok(())
+}
+
 fn dedupe_objective_ids(ids: Vec<ObjectiveId>) -> Vec<ObjectiveId> {
     let mut seen = BTreeSet::new();
     let mut out = Vec::new();
@@ -1048,6 +1179,11 @@ mod tests {
         assert!(objective
             .transition_status(ObjectiveStatus::Pending, 43)
             .is_err());
+
+        let transition_err = campaign
+            .transition_status(CampaignStatus::Active)
+            .expect_err("no-op transition must fail");
+        assert_eq!(transition_err.code(), "ML-CAMP-0002");
     }
 
     #[test]
@@ -1211,5 +1347,124 @@ mod tests {
         let a = predicate.stable_encoding();
         let b = predicate.stable_encoding();
         assert_eq!(a, b);
+    }
+
+    #[test]
+    fn graph_validation_rejects_missing_prerequisites_with_stable_error_code() {
+        let objective = Objective::new_at(
+            objective_id("0f8fad5b-d9cb-469f-a165-70867728950e"),
+            campaign_id("de305d54-75b4-431b-adb2-eb6b9e546014"),
+            "Objective A",
+            "requires unknown objective",
+            vec![objective_id("9b2f4d6a-3aa4-41ba-91ed-6308a58186a1")],
+            vec![Predicate::FindingExists {
+                finding_type: "credential".to_string(),
+            }],
+            vec![],
+            RiskLevel::Low,
+            None,
+            10,
+        )
+        .expect("objective");
+
+        let err = validate_prerequisite_graph(&[objective]).expect_err("missing reference");
+        assert_eq!(err.code(), "ML-CAMP-0003");
+    }
+
+    #[test]
+    fn graph_validation_rejects_cycles_with_stable_error_code() {
+        let campaign_id = campaign_id("de305d54-75b4-431b-adb2-eb6b9e546014");
+        let objective_a_id = objective_id("0f8fad5b-d9cb-469f-a165-70867728950e");
+        let objective_b_id = objective_id("9b2f4d6a-3aa4-41ba-91ed-6308a58186a1");
+
+        let objective_a = Objective::new_at(
+            objective_a_id.clone(),
+            campaign_id.clone(),
+            "Objective A",
+            "depends on B",
+            vec![objective_b_id.clone()],
+            vec![Predicate::FindingExists {
+                finding_type: "credential".to_string(),
+            }],
+            vec![],
+            RiskLevel::Low,
+            None,
+            10,
+        )
+        .expect("objective A");
+
+        let objective_b = Objective::new_at(
+            objective_b_id,
+            campaign_id,
+            "Objective B",
+            "depends on A",
+            vec![objective_a_id],
+            vec![Predicate::FindingExists {
+                finding_type: "credential".to_string(),
+            }],
+            vec![],
+            RiskLevel::Low,
+            None,
+            10,
+        )
+        .expect("objective B");
+
+        let err = validate_prerequisite_graph(&[objective_a, objective_b]).expect_err("cycle");
+        assert_eq!(err.code(), "ML-CAMP-0004");
+    }
+
+    #[test]
+    fn prerequisite_link_validation_prevents_cycle_creation() {
+        let campaign_id = campaign_id("de305d54-75b4-431b-adb2-eb6b9e546014");
+        let objective_a_id = objective_id("0f8fad5b-d9cb-469f-a165-70867728950e");
+        let objective_b_id = objective_id("9b2f4d6a-3aa4-41ba-91ed-6308a58186a1");
+
+        let objective_a = Objective::new_at(
+            objective_a_id.clone(),
+            campaign_id.clone(),
+            "Objective A",
+            "valid",
+            vec![],
+            vec![Predicate::FindingExists {
+                finding_type: "credential".to_string(),
+            }],
+            vec![],
+            RiskLevel::Low,
+            None,
+            10,
+        )
+        .expect("objective A");
+
+        let objective_b = Objective::new_at(
+            objective_b_id.clone(),
+            campaign_id,
+            "Objective B",
+            "depends on A",
+            vec![objective_a_id.clone()],
+            vec![Predicate::FindingExists {
+                finding_type: "credential".to_string(),
+            }],
+            vec![],
+            RiskLevel::Low,
+            None,
+            10,
+        )
+        .expect("objective B");
+
+        let err = validate_prerequisite_link(
+            &[objective_a.clone(), objective_b.clone()],
+            &objective_a_id,
+            &objective_b_id,
+        )
+        .expect_err("would create A<->B cycle");
+        assert_eq!(err.code(), "ML-CAMP-0004");
+
+        let self_ref_err = validate_prerequisite_link(
+            &[objective_a, objective_b],
+            &objective_a_id,
+            &objective_a_id,
+        )
+        .expect_err("self prereq must fail");
+        assert_eq!(self_ref_err.code(), "ML-CAMP-0001");
     }
 }

--- a/core/core/src/campaign.rs
+++ b/core/core/src/campaign.rs
@@ -1,6 +1,8 @@
 use std::collections::{BTreeMap, BTreeSet};
 use std::fmt;
 
+use crate::domain;
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum CampaignModelError {
     InvalidField {
@@ -11,6 +13,9 @@ pub enum CampaignModelError {
         entity: &'static str,
         from: &'static str,
         to: &'static str,
+    },
+    Parse {
+        reason: &'static str,
     },
     MissingObjective {
         objective_id: ObjectiveId,
@@ -29,6 +34,7 @@ impl fmt::Display for CampaignModelError {
             CampaignModelError::InvalidTransition { entity, from, to } => {
                 write!(f, "invalid {entity} transition: {from} -> {to}")
             }
+            CampaignModelError::Parse { reason } => write!(f, "parse error: {reason}"),
             CampaignModelError::MissingObjective { objective_id } => {
                 write!(
                     f,
@@ -56,6 +62,7 @@ impl CampaignModelError {
             CampaignModelError::InvalidTransition { .. } => "ML-CAMP-0002",
             CampaignModelError::MissingObjective { .. } => "ML-CAMP-0003",
             CampaignModelError::PrerequisiteCycle { .. } => "ML-CAMP-0004",
+            CampaignModelError::Parse { .. } => "ML-CAMP-0005",
         }
     }
 }
@@ -308,6 +315,265 @@ impl MetadataValue {
             }
         }
     }
+
+    fn write_wire(&self, out: &mut Vec<u8>) {
+        match self {
+            MetadataValue::Null => out.push(0),
+            MetadataValue::Bool(false) => out.push(1),
+            MetadataValue::Bool(true) => out.push(2),
+            MetadataValue::Integer(value) => {
+                out.push(3);
+                out.extend_from_slice(&value.to_be_bytes());
+            }
+            MetadataValue::FloatBits(bits) => {
+                out.push(4);
+                out.extend_from_slice(&bits.to_be_bytes());
+            }
+            MetadataValue::Text(value) => {
+                out.push(5);
+                write_string(out, value);
+            }
+            MetadataValue::Array(values) => {
+                out.push(6);
+                write_u32(out, values.len() as u32);
+                for value in values {
+                    value.write_wire(out);
+                }
+            }
+            MetadataValue::Object(map) => {
+                out.push(7);
+                write_u32(out, map.len() as u32);
+                for (key, value) in map {
+                    write_string(out, key);
+                    value.write_wire(out);
+                }
+            }
+        }
+    }
+
+    fn read_wire(cursor: &mut WireCursor<'_>) -> Result<Self, CampaignModelError> {
+        let tag = cursor.read_u8()?;
+        match tag {
+            0 => Ok(MetadataValue::Null),
+            1 => Ok(MetadataValue::Bool(false)),
+            2 => Ok(MetadataValue::Bool(true)),
+            3 => Ok(MetadataValue::Integer(cursor.read_i64()?)),
+            4 => Ok(MetadataValue::FloatBits(cursor.read_u64()?)),
+            5 => Ok(MetadataValue::Text(cursor.read_string()?)),
+            6 => {
+                let count = cursor.read_u32()? as usize;
+                let mut values = Vec::with_capacity(count);
+                for _ in 0..count {
+                    values.push(MetadataValue::read_wire(cursor)?);
+                }
+                Ok(MetadataValue::Array(values))
+            }
+            7 => {
+                let count = cursor.read_u32()? as usize;
+                let mut map = BTreeMap::new();
+                for _ in 0..count {
+                    let key = cursor.read_string()?;
+                    if map.contains_key(&key) {
+                        return Err(CampaignModelError::Parse {
+                            reason: "duplicate metadata object key",
+                        });
+                    }
+                    map.insert(key, MetadataValue::read_wire(cursor)?);
+                }
+                Ok(MetadataValue::Object(map))
+            }
+            _ => Err(CampaignModelError::Parse {
+                reason: "unknown metadata tag",
+            }),
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ArtifactSnapshot {
+    pub artifact: domain::Artifact,
+    pub tags: BTreeSet<String>,
+    pub metadata: BTreeMap<String, MetadataValue>,
+}
+
+impl ArtifactSnapshot {
+    pub fn new(artifact: domain::Artifact) -> Self {
+        Self {
+            artifact,
+            tags: BTreeSet::new(),
+            metadata: BTreeMap::new(),
+        }
+    }
+
+    pub fn with_tag(mut self, tag: &str) -> Self {
+        self.tags.insert(normalize_token(tag));
+        self
+    }
+
+    pub fn with_metadata(mut self, key: &str, value: MetadataValue) -> Self {
+        self.metadata.insert(normalize_token(key), value);
+        self
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct FindingSnapshot {
+    pub finding: domain::Finding,
+    pub finding_type: String,
+    pub metadata: BTreeMap<String, MetadataValue>,
+}
+
+impl FindingSnapshot {
+    pub fn new(finding: domain::Finding, finding_type: &str) -> Result<Self, CampaignModelError> {
+        ensure_non_empty(finding_type, "finding_snapshot.finding_type")?;
+        Ok(Self {
+            finding,
+            finding_type: normalize_token(finding_type),
+            metadata: BTreeMap::new(),
+        })
+    }
+
+    pub fn with_metadata(mut self, key: &str, value: MetadataValue) -> Self {
+        self.metadata.insert(normalize_token(key), value);
+        self
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SessionSnapshot {
+    pub session: domain::Session,
+    pub privilege: Option<SessionPrivilegeLevel>,
+    pub metadata: BTreeMap<String, MetadataValue>,
+}
+
+impl SessionSnapshot {
+    pub fn new(session: domain::Session) -> Self {
+        Self {
+            session,
+            privilege: None,
+            metadata: BTreeMap::new(),
+        }
+    }
+
+    pub fn with_privilege(mut self, privilege: SessionPrivilegeLevel) -> Self {
+        self.privilege = Some(privilege);
+        self
+    }
+
+    pub fn with_metadata(mut self, key: &str, value: MetadataValue) -> Self {
+        self.metadata.insert(normalize_token(key), value);
+        self
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RunSnapshot {
+    pub run: domain::Run,
+    pub module_name: String,
+    pub metadata: BTreeMap<String, MetadataValue>,
+}
+
+impl RunSnapshot {
+    pub fn new(run: domain::Run, module_name: &str) -> Result<Self, CampaignModelError> {
+        ensure_non_empty(module_name, "run_snapshot.module_name")?;
+        Ok(Self {
+            run,
+            module_name: normalize_token(module_name),
+            metadata: BTreeMap::new(),
+        })
+    }
+
+    pub fn with_metadata(mut self, key: &str, value: MetadataValue) -> Self {
+        self.metadata.insert(normalize_token(key), value);
+        self
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PredicateSnapshot {
+    pub artifacts: Vec<ArtifactSnapshot>,
+    pub findings: Vec<FindingSnapshot>,
+    pub sessions: Vec<SessionSnapshot>,
+    pub runs: Vec<RunSnapshot>,
+    pub metadata: BTreeMap<String, MetadataValue>,
+}
+
+impl PredicateSnapshot {
+    pub fn new() -> Self {
+        Self {
+            artifacts: Vec::new(),
+            findings: Vec::new(),
+            sessions: Vec::new(),
+            runs: Vec::new(),
+            metadata: BTreeMap::new(),
+        }
+    }
+
+    pub fn with_artifact(mut self, artifact: ArtifactSnapshot) -> Self {
+        self.artifacts.push(artifact);
+        self
+    }
+
+    pub fn with_finding(mut self, finding: FindingSnapshot) -> Self {
+        self.findings.push(finding);
+        self
+    }
+
+    pub fn with_session(mut self, session: SessionSnapshot) -> Self {
+        self.sessions.push(session);
+        self
+    }
+
+    pub fn with_run(mut self, run: RunSnapshot) -> Self {
+        self.runs.push(run);
+        self
+    }
+
+    pub fn with_metadata(mut self, key: &str, value: MetadataValue) -> Self {
+        self.metadata.insert(normalize_token(key), value);
+        self
+    }
+
+    fn contains_metadata_match(&self, key: &str, value: &MetadataValue) -> bool {
+        let token = normalize_token(key);
+        if self
+            .metadata
+            .get(&token)
+            .is_some_and(|existing| existing == value)
+        {
+            return true;
+        }
+        if self
+            .artifacts
+            .iter()
+            .any(|artifact| artifact.metadata.get(&token).is_some_and(|v| v == value))
+        {
+            return true;
+        }
+        if self
+            .findings
+            .iter()
+            .any(|finding| finding.metadata.get(&token).is_some_and(|v| v == value))
+        {
+            return true;
+        }
+        if self
+            .sessions
+            .iter()
+            .any(|session| session.metadata.get(&token).is_some_and(|v| v == value))
+        {
+            return true;
+        }
+        self.runs
+            .iter()
+            .any(|run| run.metadata.get(&token).is_some_and(|v| v == value))
+    }
+}
+
+impl Default for PredicateSnapshot {
+    fn default() -> Self {
+        Self::new()
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -362,6 +628,109 @@ impl Predicate {
                 .map(|actual| actual == value)
                 .unwrap_or(false),
         }
+    }
+
+    pub fn evaluate_snapshot(&self, snapshot: &PredicateSnapshot) -> bool {
+        match self {
+            Predicate::FindingExists { finding_type } => snapshot
+                .findings
+                .iter()
+                .any(|finding| finding.finding_type == normalize_token(finding_type)),
+            Predicate::SessionPrivilege { level } => snapshot
+                .sessions
+                .iter()
+                .any(|session| session.privilege == Some(*level)),
+            Predicate::ArtifactTagMatch { tag } => {
+                let token = normalize_token(tag);
+                snapshot
+                    .artifacts
+                    .iter()
+                    .any(|artifact| artifact.tags.contains(&token))
+            }
+            Predicate::RunSucceeded { module_name } => {
+                let token = normalize_token(module_name);
+                snapshot.runs.iter().any(|run| {
+                    run.module_name == token && run.run.state == domain::RunState::Succeeded
+                })
+            }
+            Predicate::CustomMetadataMatch { key, value } => {
+                snapshot.contains_metadata_match(key, value)
+            }
+        }
+    }
+
+    pub fn to_wire_bytes(&self) -> Vec<u8> {
+        let mut out = Vec::new();
+        match self {
+            Predicate::FindingExists { finding_type } => {
+                out.push(1);
+                write_string(&mut out, &normalize_token(finding_type));
+            }
+            Predicate::SessionPrivilege { level } => {
+                out.push(2);
+                out.push(match level {
+                    SessionPrivilegeLevel::User => 0,
+                    SessionPrivilegeLevel::Elevated => 1,
+                    SessionPrivilegeLevel::Root => 2,
+                });
+            }
+            Predicate::ArtifactTagMatch { tag } => {
+                out.push(3);
+                write_string(&mut out, &normalize_token(tag));
+            }
+            Predicate::RunSucceeded { module_name } => {
+                out.push(4);
+                write_string(&mut out, &normalize_token(module_name));
+            }
+            Predicate::CustomMetadataMatch { key, value } => {
+                out.push(5);
+                write_string(&mut out, &normalize_token(key));
+                value.write_wire(&mut out);
+            }
+        }
+        out
+    }
+
+    pub fn from_wire_bytes(input: &[u8]) -> Result<Self, CampaignModelError> {
+        let mut cursor = WireCursor::new(input);
+        let tag = cursor.read_u8()?;
+        let predicate = match tag {
+            1 => Predicate::FindingExists {
+                finding_type: cursor.read_string()?,
+            },
+            2 => {
+                let privilege = cursor.read_u8()?;
+                let level = match privilege {
+                    0 => SessionPrivilegeLevel::User,
+                    1 => SessionPrivilegeLevel::Elevated,
+                    2 => SessionPrivilegeLevel::Root,
+                    _ => {
+                        return Err(CampaignModelError::Parse {
+                            reason: "unknown session privilege level tag",
+                        });
+                    }
+                };
+                Predicate::SessionPrivilege { level }
+            }
+            3 => Predicate::ArtifactTagMatch {
+                tag: cursor.read_string()?,
+            },
+            4 => Predicate::RunSucceeded {
+                module_name: cursor.read_string()?,
+            },
+            5 => {
+                let key = cursor.read_string()?;
+                let value = MetadataValue::read_wire(&mut cursor)?;
+                Predicate::CustomMetadataMatch { key, value }
+            }
+            _ => {
+                return Err(CampaignModelError::Parse {
+                    reason: "unknown predicate tag",
+                });
+            }
+        };
+        cursor.ensure_finished()?;
+        Ok(predicate)
     }
 }
 
@@ -580,10 +949,22 @@ impl Objective {
             .all(|predicate| predicate.evaluate(view))
     }
 
+    pub fn success_criteria_satisfied_snapshot(&self, snapshot: &PredicateSnapshot) -> bool {
+        self.success_criteria
+            .iter()
+            .all(|predicate| predicate.evaluate_snapshot(snapshot))
+    }
+
     pub fn failure_criteria_satisfied(&self, view: &PredicateEvaluationView) -> bool {
         self.failure_criteria
             .iter()
             .any(|predicate| predicate.evaluate(view))
+    }
+
+    pub fn failure_criteria_satisfied_snapshot(&self, snapshot: &PredicateSnapshot) -> bool {
+        self.failure_criteria
+            .iter()
+            .any(|predicate| predicate.evaluate_snapshot(snapshot))
     }
 
     pub fn evaluate_transition(
@@ -593,6 +974,33 @@ impl Objective {
     ) -> ObjectiveEvaluationResult {
         let success_criteria_satisfied = self.success_criteria_satisfied(view);
         let failure_criteria_satisfied = self.failure_criteria_satisfied(view);
+
+        let next_status = match self.status {
+            ObjectiveStatus::Pending if prerequisites_satisfied => Some(ObjectiveStatus::Eligible),
+            ObjectiveStatus::InProgress if failure_criteria_satisfied => {
+                Some(ObjectiveStatus::Failed)
+            }
+            ObjectiveStatus::InProgress if success_criteria_satisfied => {
+                Some(ObjectiveStatus::Achieved)
+            }
+            _ => None,
+        };
+
+        ObjectiveEvaluationResult {
+            prerequisites_satisfied,
+            success_criteria_satisfied,
+            failure_criteria_satisfied,
+            next_status,
+        }
+    }
+
+    pub fn evaluate_transition_snapshot(
+        &self,
+        prerequisites_satisfied: bool,
+        snapshot: &PredicateSnapshot,
+    ) -> ObjectiveEvaluationResult {
+        let success_criteria_satisfied = self.success_criteria_satisfied_snapshot(snapshot);
+        let failure_criteria_satisfied = self.failure_criteria_satisfied_snapshot(snapshot);
 
         let next_status = match self.status {
             ObjectiveStatus::Pending if prerequisites_satisfied => Some(ObjectiveStatus::Eligible),
@@ -922,6 +1330,75 @@ pub struct CampaignEvent {
     pub payload: CampaignEventPayload,
 }
 
+struct WireCursor<'a> {
+    data: &'a [u8],
+    offset: usize,
+}
+
+impl<'a> WireCursor<'a> {
+    fn new(data: &'a [u8]) -> Self {
+        Self { data, offset: 0 }
+    }
+
+    fn read_u8(&mut self) -> Result<u8, CampaignModelError> {
+        let byte = *self
+            .data
+            .get(self.offset)
+            .ok_or(CampaignModelError::Parse {
+                reason: "unexpected end of input",
+            })?;
+        self.offset += 1;
+        Ok(byte)
+    }
+
+    fn read_exact<const N: usize>(&mut self) -> Result<[u8; N], CampaignModelError> {
+        if self.offset + N > self.data.len() {
+            return Err(CampaignModelError::Parse {
+                reason: "unexpected end of input",
+            });
+        }
+        let mut buf = [0u8; N];
+        buf.copy_from_slice(&self.data[self.offset..self.offset + N]);
+        self.offset += N;
+        Ok(buf)
+    }
+
+    fn read_u32(&mut self) -> Result<u32, CampaignModelError> {
+        Ok(u32::from_be_bytes(self.read_exact::<4>()?))
+    }
+
+    fn read_u64(&mut self) -> Result<u64, CampaignModelError> {
+        Ok(u64::from_be_bytes(self.read_exact::<8>()?))
+    }
+
+    fn read_i64(&mut self) -> Result<i64, CampaignModelError> {
+        Ok(i64::from_be_bytes(self.read_exact::<8>()?))
+    }
+
+    fn read_string(&mut self) -> Result<String, CampaignModelError> {
+        let len = self.read_u32()? as usize;
+        if self.offset + len > self.data.len() {
+            return Err(CampaignModelError::Parse {
+                reason: "string length exceeds input buffer",
+            });
+        }
+        let raw = &self.data[self.offset..self.offset + len];
+        self.offset += len;
+        String::from_utf8(raw.to_vec()).map_err(|_| CampaignModelError::Parse {
+            reason: "invalid utf-8 string",
+        })
+    }
+
+    fn ensure_finished(&self) -> Result<(), CampaignModelError> {
+        if self.offset != self.data.len() {
+            return Err(CampaignModelError::Parse {
+                reason: "extra bytes at end of input",
+            });
+        }
+        Ok(())
+    }
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum VisitState {
     Visiting,
@@ -1031,6 +1508,15 @@ fn dedupe_objective_ids(ids: Vec<ObjectiveId>) -> Vec<ObjectiveId> {
         }
     }
     out
+}
+
+fn write_u32(out: &mut Vec<u8>, value: u32) {
+    out.extend_from_slice(&value.to_be_bytes());
+}
+
+fn write_string(out: &mut Vec<u8>, value: &str) {
+    write_u32(out, value.len() as u32);
+    out.extend_from_slice(value.as_bytes());
 }
 
 fn ensure_non_empty(value: &str, field: &'static str) -> Result<(), CampaignModelError> {
@@ -1466,5 +1952,191 @@ mod tests {
         )
         .expect_err("self prereq must fail");
         assert_eq!(self_ref_err.code(), "ML-CAMP-0001");
+    }
+
+    #[test]
+    fn predicate_wire_serialization_round_trip_is_deterministic() {
+        let predicates = vec![
+            Predicate::FindingExists {
+                finding_type: "credential".to_string(),
+            },
+            Predicate::SessionPrivilege {
+                level: SessionPrivilegeLevel::Elevated,
+            },
+            Predicate::ArtifactTagMatch {
+                tag: "loot".to_string(),
+            },
+            Predicate::RunSucceeded {
+                module_name: "exploit/linux/example".to_string(),
+            },
+            Predicate::CustomMetadataMatch {
+                key: "owner".to_string(),
+                value: MetadataValue::Object(BTreeMap::from([
+                    (
+                        "team".to_string(),
+                        MetadataValue::Text("purple".to_string()),
+                    ),
+                    ("risk".to_string(), MetadataValue::Integer(2)),
+                ])),
+            },
+        ];
+
+        for predicate in predicates {
+            let encoded_a = predicate.to_wire_bytes();
+            let encoded_b = predicate.to_wire_bytes();
+            assert_eq!(encoded_a, encoded_b, "wire bytes must be deterministic");
+
+            let decoded = Predicate::from_wire_bytes(&encoded_a).expect("decode predicate");
+            assert_eq!(decoded, predicate);
+            assert_eq!(decoded.to_wire_bytes(), encoded_a);
+        }
+    }
+
+    #[test]
+    fn predicate_snapshot_evaluation_is_pure_and_replay_safe() {
+        let workspace = domain::Workspace::new_at("ws", "test", 1).expect("workspace");
+        let module = domain::ModuleVersion::new_at(
+            "exploit/linux/example",
+            "1.0.0",
+            1,
+            "entrypoint",
+            "sha256",
+            1,
+        )
+        .expect("module");
+        let mut run =
+            domain::Run::new_at(workspace.id, module.id, None, "operator", 2).expect("run");
+        run.transition_state(domain::RunState::Running, 3)
+            .expect("run running");
+        run.transition_state(domain::RunState::Succeeded, 4)
+            .expect("run succeeded");
+
+        let mut session =
+            domain::Session::new_at(run.id, None, "shell", "127.0.0.1:23", 5).expect("session");
+        session
+            .transition_state(domain::SessionState::Open, 6)
+            .expect("session open");
+
+        let mut artifact = domain::Artifact::new_at(
+            run.id,
+            None,
+            Some(session.id),
+            domain::ArtifactKind::CommandOutput,
+            "cmd-out",
+            "memory://1",
+            7,
+        )
+        .expect("artifact");
+        artifact
+            .transition_state(domain::ArtifactState::Available, 8)
+            .expect("artifact available");
+
+        let finding = domain::Finding::new_at(
+            run.id,
+            None,
+            Some(session.id),
+            "Credential found",
+            "password in config",
+            domain::FindingSeverity::High,
+            9,
+        )
+        .expect("finding");
+
+        let snapshot = PredicateSnapshot::new()
+            .with_run(
+                RunSnapshot::new(run, "exploit/linux/example")
+                    .expect("run snapshot")
+                    .with_metadata("owner", MetadataValue::Text("red".to_string())),
+            )
+            .with_session(
+                SessionSnapshot::new(session)
+                    .with_privilege(SessionPrivilegeLevel::Root)
+                    .with_metadata("channel", MetadataValue::Text("pty".to_string())),
+            )
+            .with_artifact(
+                ArtifactSnapshot::new(artifact)
+                    .with_tag("loot")
+                    .with_metadata("path", MetadataValue::Text("/tmp/loot".to_string())),
+            )
+            .with_finding(
+                FindingSnapshot::new(finding, "credential")
+                    .expect("finding snapshot")
+                    .with_metadata("source", MetadataValue::Text("procfs".to_string())),
+            )
+            .with_metadata("owner", MetadataValue::Text("red".to_string()));
+
+        let predicates = vec![
+            Predicate::FindingExists {
+                finding_type: "credential".to_string(),
+            },
+            Predicate::SessionPrivilege {
+                level: SessionPrivilegeLevel::Root,
+            },
+            Predicate::ArtifactTagMatch {
+                tag: "loot".to_string(),
+            },
+            Predicate::RunSucceeded {
+                module_name: "exploit/linux/example".to_string(),
+            },
+            Predicate::CustomMetadataMatch {
+                key: "owner".to_string(),
+                value: MetadataValue::Text("red".to_string()),
+            },
+            Predicate::CustomMetadataMatch {
+                key: "path".to_string(),
+                value: MetadataValue::Text("/tmp/loot".to_string()),
+            },
+        ];
+
+        for predicate in predicates {
+            let first = predicate.evaluate_snapshot(&snapshot);
+            let second = predicate.evaluate_snapshot(&snapshot);
+            assert_eq!(first, second, "evaluation must be deterministic");
+            assert!(first, "predicate must match immutable snapshot");
+        }
+    }
+
+    #[test]
+    fn objective_snapshot_evaluation_matches_for_identical_inputs() {
+        let objective = Objective::new_at(
+            objective_id("7f5f5d5c-f9a9-42dc-a0ef-3d96f5565de8"),
+            campaign_id("de305d54-75b4-431b-adb2-eb6b9e546014"),
+            "Escalate",
+            "Get root",
+            vec![],
+            vec![Predicate::SessionPrivilege {
+                level: SessionPrivilegeLevel::Root,
+            }],
+            vec![Predicate::FindingExists {
+                finding_type: "detection".to_string(),
+            }],
+            RiskLevel::High,
+            None,
+            10,
+        )
+        .expect("objective");
+
+        let workspace = domain::Workspace::new_at("ws", "test", 1).expect("workspace");
+        let module = domain::ModuleVersion::new_at(
+            "exploit/linux/example",
+            "1.0.0",
+            1,
+            "entrypoint",
+            "sha256",
+            1,
+        )
+        .expect("module");
+        let run = domain::Run::new_at(workspace.id, module.id, None, "operator", 2).expect("run");
+        let session =
+            domain::Session::new_at(run.id, None, "shell", "127.0.0.1:23", 3).expect("session");
+        let snapshot = PredicateSnapshot::new()
+            .with_run(RunSnapshot::new(run, "exploit/linux/example").expect("run snapshot"))
+            .with_session(
+                SessionSnapshot::new(session).with_privilege(SessionPrivilegeLevel::Root),
+            );
+
+        let first = objective.evaluate_transition_snapshot(true, &snapshot);
+        let second = objective.evaluate_transition_snapshot(true, &snapshot);
+        assert_eq!(first, second);
     }
 }

--- a/core/core/src/campaign.rs
+++ b/core/core/src/campaign.rs
@@ -316,6 +316,19 @@ impl MetadataValue {
         }
     }
 
+    pub fn to_wire_bytes(&self) -> Vec<u8> {
+        let mut out = Vec::new();
+        self.write_wire(&mut out);
+        out
+    }
+
+    pub fn from_wire_bytes(input: &[u8]) -> Result<Self, CampaignModelError> {
+        let mut cursor = WireCursor::new(input);
+        let value = Self::read_wire(&mut cursor)?;
+        cursor.ensure_finished()?;
+        Ok(value)
+    }
+
     fn write_wire(&self, out: &mut Vec<u8>) {
         match self {
             MetadataValue::Null => out.push(0),

--- a/core/core/src/campaign.rs
+++ b/core/core/src/campaign.rs
@@ -1456,7 +1456,7 @@ pub enum CampaignEventPayload {
         name: String,
         risk_level: RiskLevel,
     },
-    ObjectivePrerequisiteLinked {
+    ObjectivePrereqLinked {
         campaign_id: CampaignId,
         objective_id: ObjectiveId,
         prerequisite_id: ObjectiveId,
@@ -1484,7 +1484,7 @@ pub enum CampaignEventType {
     CampaignCreated,
     CampaignStatusChanged,
     ObjectiveCreated,
-    ObjectivePrerequisiteLinked,
+    ObjectivePrereqLinked,
     ObjectiveStatusChanged,
     ObjectiveEvaluated,
 }
@@ -1495,7 +1495,7 @@ impl CampaignEventType {
             CampaignEventType::CampaignCreated => "campaign_created",
             CampaignEventType::CampaignStatusChanged => "campaign_status_changed",
             CampaignEventType::ObjectiveCreated => "objective_created",
-            CampaignEventType::ObjectivePrerequisiteLinked => "objective_prerequisite_linked",
+            CampaignEventType::ObjectivePrereqLinked => "objective_prereq_linked",
             CampaignEventType::ObjectiveStatusChanged => "objective_status_changed",
             CampaignEventType::ObjectiveEvaluated => "objective_evaluated",
         }
@@ -1506,7 +1506,7 @@ pub const CAMPAIGN_EVENT_TAXONOMY: &[CampaignEventType] = &[
     CampaignEventType::CampaignCreated,
     CampaignEventType::CampaignStatusChanged,
     CampaignEventType::ObjectiveCreated,
-    CampaignEventType::ObjectivePrerequisiteLinked,
+    CampaignEventType::ObjectivePrereqLinked,
     CampaignEventType::ObjectiveStatusChanged,
     CampaignEventType::ObjectiveEvaluated,
 ];
@@ -1519,8 +1519,8 @@ impl CampaignEventPayload {
                 CampaignEventType::CampaignStatusChanged
             }
             CampaignEventPayload::ObjectiveCreated { .. } => CampaignEventType::ObjectiveCreated,
-            CampaignEventPayload::ObjectivePrerequisiteLinked { .. } => {
-                CampaignEventType::ObjectivePrerequisiteLinked
+            CampaignEventPayload::ObjectivePrereqLinked { .. } => {
+                CampaignEventType::ObjectivePrereqLinked
             }
             CampaignEventPayload::ObjectiveStatusChanged { .. } => {
                 CampaignEventType::ObjectiveStatusChanged
@@ -1530,7 +1530,43 @@ impl CampaignEventPayload {
             }
         }
     }
+
+    pub fn campaign_id(&self) -> &CampaignId {
+        match self {
+            CampaignEventPayload::CampaignCreated { campaign_id, .. } => campaign_id,
+            CampaignEventPayload::CampaignStatusChanged { campaign_id, .. } => campaign_id,
+            CampaignEventPayload::ObjectiveCreated { campaign_id, .. } => campaign_id,
+            CampaignEventPayload::ObjectivePrereqLinked { campaign_id, .. } => campaign_id,
+            CampaignEventPayload::ObjectiveStatusChanged { campaign_id, .. } => campaign_id,
+            CampaignEventPayload::ObjectiveEvaluated { campaign_id, .. } => campaign_id,
+        }
+    }
 }
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum CampaignEventSequenceRule {
+    AppendOnly,
+    MonotonicPerCampaignLineage,
+    GaplessPerCampaignLineage,
+}
+
+impl CampaignEventSequenceRule {
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            CampaignEventSequenceRule::AppendOnly => "append_only",
+            CampaignEventSequenceRule::MonotonicPerCampaignLineage => {
+                "monotonic_per_campaign_lineage"
+            }
+            CampaignEventSequenceRule::GaplessPerCampaignLineage => "gapless_per_campaign_lineage",
+        }
+    }
+}
+
+pub const CAMPAIGN_EVENT_SEQUENCE_RULES: &[CampaignEventSequenceRule] = &[
+    CampaignEventSequenceRule::AppendOnly,
+    CampaignEventSequenceRule::MonotonicPerCampaignLineage,
+    CampaignEventSequenceRule::GaplessPerCampaignLineage,
+];
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct CampaignEvent {

--- a/core/core/src/campaign.rs
+++ b/core/core/src/campaign.rs
@@ -1252,6 +1252,59 @@ impl ObjectiveEvaluationEngine {
         })
     }
 
+    pub fn evaluate_selected<H: ObjectiveEventHook>(
+        objectives: &mut BTreeMap<ObjectiveId, Objective>,
+        selected: &BTreeSet<ObjectiveId>,
+        snapshot: &PredicateSnapshot,
+        trigger: ObjectiveReevaluationTrigger,
+        now: u64,
+        hook: &mut H,
+    ) -> Result<Vec<ObjectiveEvaluationRecord>, CampaignModelError> {
+        validate_prerequisite_graph(&objectives.values().cloned().collect::<Vec<_>>())?;
+        if selected.is_empty() {
+            return Ok(Vec::new());
+        }
+
+        let mut records = Vec::new();
+        let max_iterations = selected.len().saturating_mul(4).max(1);
+        for _ in 0..max_iterations {
+            let status_index = objectives
+                .iter()
+                .map(|(id, objective)| (id.clone(), objective.status))
+                .collect::<BTreeMap<_, _>>();
+
+            let mut changed = false;
+            for objective_id in selected {
+                let objective = objectives.get_mut(objective_id).ok_or_else(|| {
+                    CampaignModelError::MissingObjective {
+                        objective_id: objective_id.clone(),
+                    }
+                })?;
+                let result = Self::evaluate_objective(
+                    objective,
+                    &status_index,
+                    snapshot,
+                    trigger,
+                    now,
+                    hook,
+                )?;
+                changed |= result.next_status.is_some();
+                records.push(ObjectiveEvaluationRecord {
+                    objective_id: objective_id.clone(),
+                    result,
+                });
+            }
+            if !changed {
+                return Ok(records);
+            }
+        }
+
+        Err(CampaignModelError::InvalidField {
+            field: "objective.evaluation",
+            reason: "selected evaluation exceeded deterministic iteration budget",
+        })
+    }
+
     pub fn start_objective<H: ObjectiveEventHook>(
         objective: &mut Objective,
         objective_statuses: &BTreeMap<ObjectiveId, ObjectiveStatus>,
@@ -1298,6 +1351,168 @@ impl ObjectiveEvaluationEngine {
             }
         }
         Ok(true)
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ObjectiveIngestionEvent {
+    pub campaign_id: CampaignId,
+    pub trigger: ObjectiveReevaluationTrigger,
+    pub source_event_key: String,
+}
+
+impl ObjectiveIngestionEvent {
+    pub fn new(
+        campaign_id: CampaignId,
+        trigger: ObjectiveReevaluationTrigger,
+        source_event_key: &str,
+    ) -> Result<Self, CampaignModelError> {
+        ensure_non_empty(source_event_key, "objective_ingestion.source_event_key")?;
+        Ok(Self {
+            campaign_id,
+            trigger,
+            source_event_key: source_event_key.trim().to_string(),
+        })
+    }
+
+    pub fn dedupe_key(&self) -> String {
+        format!(
+            "{}|{}|{}",
+            self.campaign_id.as_str(),
+            self.trigger.as_str(),
+            normalize_token(&self.source_event_key)
+        )
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ObjectiveIngestionDispatch {
+    pub skipped_duplicate: bool,
+    pub selected_objectives: Vec<ObjectiveId>,
+    pub records: Vec<ObjectiveEvaluationRecord>,
+    pub emitted_events: Vec<CampaignEventPayload>,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct ObjectiveIngestionDispatcher {
+    seen_event_keys: BTreeSet<String>,
+}
+
+impl ObjectiveIngestionDispatcher {
+    pub fn dispatch(
+        &mut self,
+        event: &ObjectiveIngestionEvent,
+        objectives: &mut BTreeMap<ObjectiveId, Objective>,
+        snapshot: &PredicateSnapshot,
+        now: u64,
+    ) -> Result<ObjectiveIngestionDispatch, CampaignModelError> {
+        let dedupe_key = event.dedupe_key();
+        if self.seen_event_keys.contains(&dedupe_key) {
+            return Ok(ObjectiveIngestionDispatch {
+                skipped_duplicate: true,
+                selected_objectives: Vec::new(),
+                records: Vec::new(),
+                emitted_events: Vec::new(),
+            });
+        }
+
+        for objective in objectives.values() {
+            if objective.campaign_id != event.campaign_id {
+                return Err(CampaignModelError::InvalidField {
+                    field: "objective.campaign_id",
+                    reason: "all objectives must match ingestion campaign",
+                });
+            }
+        }
+
+        let selected = select_relevant_objectives(event.trigger, objectives);
+        let mut emitted_events = Vec::<CampaignEventPayload>::new();
+        let records = ObjectiveEvaluationEngine::evaluate_selected(
+            objectives,
+            &selected,
+            snapshot,
+            event.trigger,
+            now,
+            &mut emitted_events,
+        )?;
+
+        self.seen_event_keys.insert(dedupe_key);
+        Ok(ObjectiveIngestionDispatch {
+            skipped_duplicate: false,
+            selected_objectives: selected.into_iter().collect(),
+            records,
+            emitted_events,
+        })
+    }
+}
+
+pub fn select_relevant_objectives(
+    trigger: ObjectiveReevaluationTrigger,
+    objectives: &BTreeMap<ObjectiveId, Objective>,
+) -> BTreeSet<ObjectiveId> {
+    let mut selected = BTreeSet::<ObjectiveId>::new();
+    for (objective_id, objective) in objectives {
+        if objective.status.is_terminal() {
+            continue;
+        }
+        if objective_matches_trigger(objective, trigger) || !objective.prerequisites.is_empty() {
+            selected.insert(objective_id.clone());
+        }
+    }
+
+    let mut changed = true;
+    while changed {
+        changed = false;
+        for (objective_id, objective) in objectives {
+            if objective.status.is_terminal() || selected.contains(objective_id) {
+                continue;
+            }
+            if objective
+                .prerequisites
+                .iter()
+                .any(|prerequisite_id| selected.contains(prerequisite_id))
+            {
+                selected.insert(objective_id.clone());
+                changed = true;
+            }
+        }
+    }
+
+    selected
+}
+
+fn objective_matches_trigger(objective: &Objective, trigger: ObjectiveReevaluationTrigger) -> bool {
+    let mut predicates = objective
+        .success_criteria
+        .iter()
+        .chain(objective.failure_criteria.iter());
+    match trigger {
+        ObjectiveReevaluationTrigger::ArtifactCreated => predicates.any(|predicate| {
+            matches!(
+                predicate,
+                Predicate::ArtifactTagMatch { .. } | Predicate::CustomMetadataMatch { .. }
+            )
+        }),
+        ObjectiveReevaluationTrigger::FindingCreated => predicates.any(|predicate| {
+            matches!(
+                predicate,
+                Predicate::FindingExists { .. } | Predicate::CustomMetadataMatch { .. }
+            )
+        }),
+        ObjectiveReevaluationTrigger::SessionStateChanged => predicates.any(|predicate| {
+            matches!(
+                predicate,
+                Predicate::SessionPrivilege { .. } | Predicate::CustomMetadataMatch { .. }
+            )
+        }),
+        ObjectiveReevaluationTrigger::RunCompleted => predicates.any(|predicate| {
+            matches!(
+                predicate,
+                Predicate::RunSucceeded { .. } | Predicate::CustomMetadataMatch { .. }
+            )
+        }),
+        ObjectiveReevaluationTrigger::ReplayRecovery
+        | ObjectiveReevaluationTrigger::ManualRequest => true,
     }
 }
 
@@ -2608,5 +2823,116 @@ mod tests {
         let first = objective.evaluate_transition_snapshot(true, &snapshot);
         let second = objective.evaluate_transition_snapshot(true, &snapshot);
         assert_eq!(first, second);
+    }
+
+    #[test]
+    fn relevant_selector_filters_by_trigger_and_dependencies() {
+        let campaign_id = campaign_id("de305d54-75b4-431b-adb2-eb6b9e546014");
+        let objective_a_id = objective_id("0f8fad5b-d9cb-469f-a165-70867728950e");
+        let objective_b_id = objective_id("9b2f4d6a-3aa4-41ba-91ed-6308a58186a1");
+        let objective_c_id = objective_id("f47ac10b-58cc-4372-a567-0e02b2c3d479");
+
+        let objective_a = Objective::new_at(
+            objective_a_id.clone(),
+            campaign_id.clone(),
+            "A",
+            "finding-based",
+            vec![],
+            vec![Predicate::FindingExists {
+                finding_type: "credential".to_string(),
+            }],
+            vec![],
+            RiskLevel::Low,
+            None,
+            1,
+        )
+        .expect("objective a");
+        let objective_b = Objective::new_at(
+            objective_b_id.clone(),
+            campaign_id.clone(),
+            "B",
+            "depends on A",
+            vec![objective_a_id.clone()],
+            vec![Predicate::RunSucceeded {
+                module_name: "exploit/linux/example".to_string(),
+            }],
+            vec![],
+            RiskLevel::Medium,
+            None,
+            1,
+        )
+        .expect("objective b");
+        let mut objective_c = Objective::new_at(
+            objective_c_id.clone(),
+            campaign_id,
+            "C",
+            "terminal and should be ignored",
+            vec![],
+            vec![Predicate::SessionPrivilege {
+                level: SessionPrivilegeLevel::Root,
+            }],
+            vec![],
+            RiskLevel::High,
+            None,
+            1,
+        )
+        .expect("objective c");
+        objective_c.status = ObjectiveStatus::Achieved;
+
+        let objectives = BTreeMap::from([
+            (objective_a_id.clone(), objective_a),
+            (objective_b_id.clone(), objective_b),
+            (objective_c_id.clone(), objective_c),
+        ]);
+        let selected =
+            select_relevant_objectives(ObjectiveReevaluationTrigger::FindingCreated, &objectives);
+
+        assert!(selected.contains(&objective_a_id));
+        assert!(selected.contains(&objective_b_id));
+        assert!(!selected.contains(&objective_c_id));
+    }
+
+    #[test]
+    fn ingestion_dispatch_is_idempotent_for_repeated_event_keys() {
+        let campaign_id = campaign_id("de305d54-75b4-431b-adb2-eb6b9e546014");
+        let objective_id = objective_id("0f8fad5b-d9cb-469f-a165-70867728950e");
+        let objective = Objective::new_at(
+            objective_id.clone(),
+            campaign_id.clone(),
+            "Credential objective",
+            "find credential",
+            vec![],
+            vec![Predicate::FindingExists {
+                finding_type: "credential".to_string(),
+            }],
+            vec![],
+            RiskLevel::Low,
+            None,
+            1,
+        )
+        .expect("objective");
+        let mut objectives = BTreeMap::from([(objective_id.clone(), objective)]);
+
+        let event = ObjectiveIngestionEvent::new(
+            campaign_id,
+            ObjectiveReevaluationTrigger::FindingCreated,
+            "finding_created:42",
+        )
+        .expect("event");
+        let snapshot = PredicateSnapshot::new();
+        let mut dispatcher = ObjectiveIngestionDispatcher::default();
+
+        let first = dispatcher
+            .dispatch(&event, &mut objectives, &snapshot, 2)
+            .expect("first dispatch");
+        assert!(!first.skipped_duplicate);
+        assert!(!first.emitted_events.is_empty());
+
+        let second = dispatcher
+            .dispatch(&event, &mut objectives, &snapshot, 3)
+            .expect("second dispatch");
+        assert!(second.skipped_duplicate);
+        assert!(second.emitted_events.is_empty());
+        assert!(second.records.is_empty());
     }
 }

--- a/core/core/src/campaign.rs
+++ b/core/core/src/campaign.rs
@@ -1021,7 +1021,7 @@ impl Objective {
         }
     }
 
-    pub fn transition_to_eligible(
+    fn transition_to_eligible(
         &mut self,
         prerequisites_satisfied: bool,
         now: u64,
@@ -1035,11 +1035,11 @@ impl Objective {
         self.transition_status(ObjectiveStatus::Eligible, now)
     }
 
-    pub fn transition_to_in_progress(&mut self, now: u64) -> Result<(), CampaignModelError> {
+    fn transition_to_in_progress(&mut self, now: u64) -> Result<(), CampaignModelError> {
         self.transition_status(ObjectiveStatus::InProgress, now)
     }
 
-    pub fn transition_to_achieved(
+    fn transition_to_achieved(
         &mut self,
         success_criteria_satisfied: bool,
         now: u64,
@@ -1053,7 +1053,7 @@ impl Objective {
         self.transition_status(ObjectiveStatus::Achieved, now)
     }
 
-    pub fn transition_to_failed(
+    fn transition_to_failed(
         &mut self,
         failure_criteria_satisfied: bool,
         now: u64,
@@ -1067,7 +1067,7 @@ impl Objective {
         self.transition_status(ObjectiveStatus::Failed, now)
     }
 
-    pub fn transition_status(
+    fn transition_status(
         &mut self,
         next: ObjectiveStatus,
         now: u64,
@@ -1089,6 +1089,215 @@ impl Objective {
         self.status = next;
         self.updated_at = now;
         Ok(())
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ObjectiveTransitionAudit {
+    pub objective_id: ObjectiveId,
+    pub from: ObjectiveStatus,
+    pub to: ObjectiveStatus,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ObjectiveEvaluationRecord {
+    pub objective_id: ObjectiveId,
+    pub result: ObjectiveEvaluationResult,
+}
+
+pub trait ObjectiveEventHook {
+    fn emit(&mut self, payload: CampaignEventPayload);
+}
+
+impl ObjectiveEventHook for Vec<CampaignEventPayload> {
+    fn emit(&mut self, payload: CampaignEventPayload) {
+        self.push(payload);
+    }
+}
+
+pub struct ObjectiveEvaluationEngine;
+
+impl ObjectiveEvaluationEngine {
+    pub fn evaluate_objective<H: ObjectiveEventHook>(
+        objective: &mut Objective,
+        objective_statuses: &BTreeMap<ObjectiveId, ObjectiveStatus>,
+        snapshot: &PredicateSnapshot,
+        trigger: ObjectiveReevaluationTrigger,
+        now: u64,
+        hook: &mut H,
+    ) -> Result<ObjectiveEvaluationResult, CampaignModelError> {
+        let prerequisites_satisfied = Self::prerequisites_satisfied(objective, objective_statuses)?;
+        let success_criteria_satisfied = objective.success_criteria_satisfied_snapshot(snapshot);
+        let failure_criteria_satisfied = objective.failure_criteria_satisfied_snapshot(snapshot);
+
+        let mut result = ObjectiveEvaluationResult::no_transition(
+            prerequisites_satisfied,
+            success_criteria_satisfied,
+            failure_criteria_satisfied,
+        );
+        let from = objective.status;
+        let mut resulting_status = from;
+
+        if objective.status == ObjectiveStatus::Pending {
+            if prerequisites_satisfied {
+                objective.transition_to_eligible(true, now)?;
+                result.next_status = Some(ObjectiveStatus::Eligible);
+                resulting_status = ObjectiveStatus::Eligible;
+                hook.emit(CampaignEventPayload::ObjectiveStatusChanged {
+                    campaign_id: objective.campaign_id.clone(),
+                    objective_id: objective.id.clone(),
+                    from,
+                    to: ObjectiveStatus::Eligible,
+                    reason: Some("evaluator_prerequisites_satisfied".to_string()),
+                });
+            }
+        } else if objective.status == ObjectiveStatus::InProgress {
+            if failure_criteria_satisfied {
+                objective.transition_to_failed(true, now)?;
+                result.next_status = Some(ObjectiveStatus::Failed);
+                resulting_status = ObjectiveStatus::Failed;
+                hook.emit(CampaignEventPayload::ObjectiveStatusChanged {
+                    campaign_id: objective.campaign_id.clone(),
+                    objective_id: objective.id.clone(),
+                    from,
+                    to: ObjectiveStatus::Failed,
+                    reason: Some("evaluator_failure_criteria_satisfied".to_string()),
+                });
+            } else if success_criteria_satisfied {
+                objective.transition_to_achieved(true, now)?;
+                result.next_status = Some(ObjectiveStatus::Achieved);
+                resulting_status = ObjectiveStatus::Achieved;
+                hook.emit(CampaignEventPayload::ObjectiveStatusChanged {
+                    campaign_id: objective.campaign_id.clone(),
+                    objective_id: objective.id.clone(),
+                    from,
+                    to: ObjectiveStatus::Achieved,
+                    reason: Some("evaluator_success_criteria_satisfied".to_string()),
+                });
+            }
+        }
+
+        hook.emit(CampaignEventPayload::ObjectiveEvaluated {
+            campaign_id: objective.campaign_id.clone(),
+            objective_id: objective.id.clone(),
+            trigger,
+            prerequisites_satisfied: result.prerequisites_satisfied,
+            success_criteria_satisfied: result.success_criteria_satisfied,
+            failure_criteria_satisfied: result.failure_criteria_satisfied,
+            resulting_status,
+        });
+
+        Ok(result)
+    }
+
+    pub fn evaluate_campaign<H: ObjectiveEventHook>(
+        campaign_id: &CampaignId,
+        objectives: &mut BTreeMap<ObjectiveId, Objective>,
+        snapshot: &PredicateSnapshot,
+        trigger: ObjectiveReevaluationTrigger,
+        now: u64,
+        hook: &mut H,
+    ) -> Result<Vec<ObjectiveEvaluationRecord>, CampaignModelError> {
+        validate_prerequisite_graph(&objectives.values().cloned().collect::<Vec<_>>())?;
+        for objective in objectives.values() {
+            if &objective.campaign_id != campaign_id {
+                return Err(CampaignModelError::InvalidField {
+                    field: "objective.campaign_id",
+                    reason: "must match evaluation campaign",
+                });
+            }
+        }
+
+        let mut records = Vec::new();
+        let max_iterations = objectives.len().saturating_mul(4).max(1);
+        for _ in 0..max_iterations {
+            let status_index = objectives
+                .iter()
+                .map(|(id, objective)| (id.clone(), objective.status))
+                .collect::<BTreeMap<_, _>>();
+
+            let ordered_ids = objectives.keys().cloned().collect::<Vec<_>>();
+            let mut changed = false;
+
+            for objective_id in ordered_ids {
+                let objective = objectives.get_mut(&objective_id).ok_or_else(|| {
+                    CampaignModelError::MissingObjective {
+                        objective_id: objective_id.clone(),
+                    }
+                })?;
+
+                let result = Self::evaluate_objective(
+                    objective,
+                    &status_index,
+                    snapshot,
+                    trigger,
+                    now,
+                    hook,
+                )?;
+                changed |= result.next_status.is_some();
+                records.push(ObjectiveEvaluationRecord {
+                    objective_id,
+                    result,
+                });
+            }
+
+            if !changed {
+                return Ok(records);
+            }
+        }
+
+        Err(CampaignModelError::InvalidField {
+            field: "objective.evaluation",
+            reason: "evaluation exceeded deterministic iteration budget",
+        })
+    }
+
+    pub fn start_objective<H: ObjectiveEventHook>(
+        objective: &mut Objective,
+        objective_statuses: &BTreeMap<ObjectiveId, ObjectiveStatus>,
+        now: u64,
+        hook: &mut H,
+    ) -> Result<ObjectiveTransitionAudit, CampaignModelError> {
+        let prerequisites_satisfied = Self::prerequisites_satisfied(objective, objective_statuses)?;
+        if !prerequisites_satisfied {
+            return Err(CampaignModelError::InvalidField {
+                field: "objective.prerequisites",
+                reason: "all prerequisites must be achieved before starting objective",
+            });
+        }
+
+        let from = objective.status;
+        objective.transition_to_in_progress(now)?;
+        let transition = ObjectiveTransitionAudit {
+            objective_id: objective.id.clone(),
+            from,
+            to: objective.status,
+        };
+        hook.emit(CampaignEventPayload::ObjectiveStatusChanged {
+            campaign_id: objective.campaign_id.clone(),
+            objective_id: objective.id.clone(),
+            from,
+            to: objective.status,
+            reason: Some("manual_objective_start".to_string()),
+        });
+        Ok(transition)
+    }
+
+    pub fn prerequisites_satisfied(
+        objective: &Objective,
+        objective_statuses: &BTreeMap<ObjectiveId, ObjectiveStatus>,
+    ) -> Result<bool, CampaignModelError> {
+        for prerequisite in &objective.prerequisites {
+            let status = objective_statuses.get(prerequisite).ok_or_else(|| {
+                CampaignModelError::MissingObjective {
+                    objective_id: prerequisite.clone(),
+                }
+            })?;
+            if *status != ObjectiveStatus::Achieved {
+                return Ok(false);
+            }
+        }
+        Ok(true)
     }
 }
 
@@ -1733,20 +1942,245 @@ mod tests {
             10,
         )
         .expect("objective");
+        let mut status_index = BTreeMap::from([(objective.id.clone(), ObjectiveStatus::Pending)]);
+        let mut events = Vec::<CampaignEventPayload>::new();
 
-        assert!(objective.transition_to_eligible(false, 11).is_err());
-        objective
-            .transition_to_eligible(true, 11)
-            .expect("eligible");
-        objective
-            .transition_to_in_progress(12)
-            .expect("in progress");
-        assert!(objective.transition_to_achieved(false, 13).is_err());
-        objective
-            .transition_to_achieved(true, 13)
-            .expect("achieved");
+        let pending_result = ObjectiveEvaluationEngine::evaluate_objective(
+            &mut objective,
+            &status_index,
+            &PredicateSnapshot::new(),
+            ObjectiveReevaluationTrigger::ManualRequest,
+            11,
+            &mut events,
+        )
+        .expect("evaluate pending");
+        assert_eq!(objective.status, ObjectiveStatus::Eligible);
+        assert_eq!(pending_result.next_status, Some(ObjectiveStatus::Eligible));
+        assert_eq!(events.len(), 2);
+
+        status_index.insert(objective.id.clone(), objective.status);
+        ObjectiveEvaluationEngine::start_objective(&mut objective, &status_index, 12, &mut events)
+            .expect("start objective");
+        assert_eq!(objective.status, ObjectiveStatus::InProgress);
+
+        let root_snapshot = PredicateSnapshot::new().with_session(
+            SessionSnapshot::new(
+                domain::Session::new_at(
+                    domain::Run::new_at(
+                        domain::Workspace::new_at("ws", "test", 1)
+                            .expect("workspace")
+                            .id,
+                        domain::ModuleVersion::new_at(
+                            "exploit/linux/example",
+                            "1.0.0",
+                            1,
+                            "entrypoint",
+                            "sha256",
+                            1,
+                        )
+                        .expect("module")
+                        .id,
+                        None,
+                        "operator",
+                        2,
+                    )
+                    .expect("run")
+                    .id,
+                    None,
+                    "shell",
+                    "127.0.0.1:23",
+                    3,
+                )
+                .expect("session"),
+            )
+            .with_privilege(SessionPrivilegeLevel::Root),
+        );
+        status_index.insert(objective.id.clone(), objective.status);
+        let complete_result = ObjectiveEvaluationEngine::evaluate_objective(
+            &mut objective,
+            &status_index,
+            &root_snapshot,
+            ObjectiveReevaluationTrigger::SessionStateChanged,
+            13,
+            &mut events,
+        )
+        .expect("evaluate in progress");
         assert_eq!(objective.status, ObjectiveStatus::Achieved);
-        assert!(objective.transition_to_failed(true, 14).is_err());
+        assert_eq!(complete_result.next_status, Some(ObjectiveStatus::Achieved));
+    }
+
+    #[test]
+    fn evaluator_emits_auditable_transition_events() {
+        let mut objective = Objective::new_at(
+            objective_id("1f65f5d5-f9a9-42dc-a0ef-3d96f5565de8"),
+            campaign_id("de305d54-75b4-431b-adb2-eb6b9e546014"),
+            "Objective",
+            "pending to eligible",
+            vec![],
+            vec![Predicate::FindingExists {
+                finding_type: "credential".to_string(),
+            }],
+            vec![],
+            RiskLevel::Low,
+            None,
+            10,
+        )
+        .expect("objective");
+
+        let mut events = Vec::<CampaignEventPayload>::new();
+        let status_index = BTreeMap::from([(objective.id.clone(), ObjectiveStatus::Pending)]);
+
+        ObjectiveEvaluationEngine::evaluate_objective(
+            &mut objective,
+            &status_index,
+            &PredicateSnapshot::new(),
+            ObjectiveReevaluationTrigger::RunCompleted,
+            11,
+            &mut events,
+        )
+        .expect("evaluation");
+
+        assert_eq!(events.len(), 2);
+        match &events[0] {
+            CampaignEventPayload::ObjectiveStatusChanged { from, to, .. } => {
+                assert_eq!(*from, ObjectiveStatus::Pending);
+                assert_eq!(*to, ObjectiveStatus::Eligible);
+            }
+            payload => panic!("unexpected payload: {payload:?}"),
+        }
+        match &events[1] {
+            CampaignEventPayload::ObjectiveEvaluated {
+                trigger,
+                resulting_status,
+                ..
+            } => {
+                assert_eq!(*trigger, ObjectiveReevaluationTrigger::RunCompleted);
+                assert_eq!(*resulting_status, ObjectiveStatus::Eligible);
+            }
+            payload => panic!("unexpected payload: {payload:?}"),
+        }
+    }
+
+    #[test]
+    fn evaluator_campaign_pass_is_deterministic_and_auditable() {
+        let cid = campaign_id("de305d54-75b4-431b-adb2-eb6b9e546014");
+        let oid_a = objective_id("0f8fad5b-d9cb-469f-a165-70867728950e");
+        let oid_b = objective_id("9b2f4d6a-3aa4-41ba-91ed-6308a58186a1");
+
+        let objective_a = Objective::new_at(
+            oid_a.clone(),
+            cid.clone(),
+            "A",
+            "first objective",
+            vec![],
+            vec![Predicate::SessionPrivilege {
+                level: SessionPrivilegeLevel::Root,
+            }],
+            vec![],
+            RiskLevel::Low,
+            None,
+            1,
+        )
+        .expect("objective a");
+        let objective_b = Objective::new_at(
+            oid_b.clone(),
+            cid.clone(),
+            "B",
+            "depends on A",
+            vec![oid_a.clone()],
+            vec![Predicate::FindingExists {
+                finding_type: "credential".to_string(),
+            }],
+            vec![],
+            RiskLevel::Medium,
+            None,
+            1,
+        )
+        .expect("objective b");
+
+        let mut objectives =
+            BTreeMap::from([(oid_a.clone(), objective_a), (oid_b.clone(), objective_b)]);
+        let mut events_a = Vec::<CampaignEventPayload>::new();
+        let records_a = ObjectiveEvaluationEngine::evaluate_campaign(
+            &cid,
+            &mut objectives,
+            &PredicateSnapshot::new(),
+            ObjectiveReevaluationTrigger::ManualRequest,
+            2,
+            &mut events_a,
+        )
+        .expect("campaign evaluation");
+
+        assert_eq!(objectives[&oid_a].status, ObjectiveStatus::Eligible);
+        assert_eq!(objectives[&oid_b].status, ObjectiveStatus::Pending);
+        assert!(!records_a.is_empty());
+
+        let mut status_index = objectives
+            .iter()
+            .map(|(id, objective)| (id.clone(), objective.status))
+            .collect::<BTreeMap<_, _>>();
+        ObjectiveEvaluationEngine::start_objective(
+            objectives.get_mut(&oid_a).expect("objective a"),
+            &status_index,
+            3,
+            &mut events_a,
+        )
+        .expect("start objective a");
+        status_index.insert(oid_a.clone(), ObjectiveStatus::InProgress);
+
+        let root_snapshot = PredicateSnapshot::new().with_session(
+            SessionSnapshot::new(
+                domain::Session::new_at(
+                    domain::Run::new_at(
+                        domain::Workspace::new_at("ws", "test", 1)
+                            .expect("workspace")
+                            .id,
+                        domain::ModuleVersion::new_at(
+                            "exploit/linux/example",
+                            "1.0.0",
+                            1,
+                            "entrypoint",
+                            "sha256",
+                            1,
+                        )
+                        .expect("module")
+                        .id,
+                        None,
+                        "operator",
+                        1,
+                    )
+                    .expect("run")
+                    .id,
+                    None,
+                    "shell",
+                    "127.0.0.1:23",
+                    1,
+                )
+                .expect("session"),
+            )
+            .with_privilege(SessionPrivilegeLevel::Root),
+        );
+
+        let mut events_b = Vec::<CampaignEventPayload>::new();
+        let records_b = ObjectiveEvaluationEngine::evaluate_campaign(
+            &cid,
+            &mut objectives,
+            &root_snapshot,
+            ObjectiveReevaluationTrigger::SessionStateChanged,
+            4,
+            &mut events_b,
+        )
+        .expect("campaign re-evaluation");
+
+        assert_eq!(objectives[&oid_a].status, ObjectiveStatus::Achieved);
+        assert_eq!(objectives[&oid_b].status, ObjectiveStatus::Eligible);
+        assert!(!records_b.is_empty());
+        assert!(events_b
+            .iter()
+            .any(|event| matches!(event, CampaignEventPayload::ObjectiveStatusChanged { .. })));
+        assert!(events_b
+            .iter()
+            .any(|event| matches!(event, CampaignEventPayload::ObjectiveEvaluated { .. })));
     }
 
     #[test]

--- a/core/core/src/control.rs
+++ b/core/core/src/control.rs
@@ -3,6 +3,10 @@ use std::fmt;
 use std::io::Write;
 use std::path::{Path, PathBuf};
 
+use crate::campaign::{
+    validate_prerequisite_graph, Campaign, CampaignId, CampaignModelError, CampaignStatus,
+    MetadataValue, Objective, ObjectiveId, ObjectiveStatus, Predicate, RiskLevel,
+};
 use crate::domain::{
     Artifact, ArtifactId, ArtifactKind, ArtifactState, CorrelationId, DomainError, ModuleVersionId,
     Run, RunId, RunState, Session, SessionId, SessionState, TargetId, Task, TaskId, TaskState,
@@ -11,7 +15,9 @@ use crate::domain::{
 use crate::ids::Id;
 use crate::time::now_secs;
 
-const CONTROL_STATE_HEADER: &str = "moonlight-control-state:v1";
+const CONTROL_STATE_HEADER_V1: &str = "moonlight-control-state:v1";
+const CONTROL_STATE_HEADER_V2: &str = "moonlight-control-state:v2";
+const CONTROL_STATE_SCHEMA_VERSION: u32 = 4;
 const CONTROL_COMMIT_LOG_HEADER: &str = "moonlight-control-commit-log:v1";
 
 #[derive(Debug)]
@@ -43,13 +49,37 @@ impl From<DomainError> for ControlStateError {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Default)]
+impl From<CampaignModelError> for ControlStateError {
+    fn from(value: CampaignModelError) -> Self {
+        ControlStateError::Validation(value.to_string())
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ControlState {
+    pub schema_version: u32,
     pub runs: BTreeMap<RunId, Run>,
     pub tasks: BTreeMap<TaskId, Task>,
     pub sessions: BTreeMap<SessionId, Session>,
     pub artifacts: BTreeMap<ArtifactId, Artifact>,
+    pub campaigns: BTreeMap<CampaignId, Campaign>,
+    pub objectives: BTreeMap<ObjectiveId, Objective>,
     pub applied_transactions: BTreeSet<u64>,
+}
+
+impl Default for ControlState {
+    fn default() -> Self {
+        Self {
+            schema_version: CONTROL_STATE_SCHEMA_VERSION,
+            runs: BTreeMap::new(),
+            tasks: BTreeMap::new(),
+            sessions: BTreeMap::new(),
+            artifacts: BTreeMap::new(),
+            campaigns: BTreeMap::new(),
+            objectives: BTreeMap::new(),
+            applied_transactions: BTreeSet::new(),
+        }
+    }
 }
 
 impl ControlState {
@@ -81,6 +111,8 @@ pub enum ControlMutation {
     UpsertTask(Task),
     UpsertSession(Session),
     UpsertArtifact(Artifact),
+    UpsertCampaign(Campaign),
+    UpsertObjective(Objective),
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -116,9 +148,11 @@ impl ControlTransaction {
         }
 
         let mut candidate = state.clone();
+        candidate.schema_version = CONTROL_STATE_SCHEMA_VERSION;
         for mutation in &self.mutations {
             apply_mutation(&mut candidate, mutation)?;
         }
+        validate_campaign_graph_integrity(&candidate)?;
         candidate.applied_transactions.insert(self.id);
         *state = candidate;
         Ok(())
@@ -216,7 +250,87 @@ fn apply_mutation(
             }
             state.artifacts.insert(artifact.id, artifact.clone());
         }
+        ControlMutation::UpsertCampaign(campaign) => {
+            let mut next = campaign.clone();
+            let existing_objective_ids = state
+                .campaigns
+                .get(&campaign.id)
+                .map(|value| value.objective_ids.clone())
+                .unwrap_or_default();
+            for objective_id in existing_objective_ids {
+                if !next.objective_ids.contains(&objective_id) {
+                    next.objective_ids.push(objective_id);
+                }
+            }
+            for objective in state.objectives.values() {
+                if objective.campaign_id == next.id && !next.objective_ids.contains(&objective.id) {
+                    next.objective_ids.push(objective.id.clone());
+                }
+            }
+            state.campaigns.insert(next.id.clone(), next);
+        }
+        ControlMutation::UpsertObjective(objective) => {
+            state
+                .objectives
+                .insert(objective.id.clone(), objective.clone());
+            if let Some(campaign) = state.campaigns.get_mut(&objective.campaign_id) {
+                if !campaign.objective_ids.contains(&objective.id) {
+                    campaign.objective_ids.push(objective.id.clone());
+                }
+            }
+        }
     }
+    Ok(())
+}
+
+fn validate_campaign_graph_integrity(state: &ControlState) -> Result<(), ControlStateError> {
+    for objective in state.objectives.values() {
+        let Some(campaign) = state.campaigns.get(&objective.campaign_id) else {
+            return Err(ControlStateError::Validation(format!(
+                "objective {} references missing campaign {}",
+                objective.id.as_str(),
+                objective.campaign_id.as_str()
+            )));
+        };
+        if !campaign.objective_ids.contains(&objective.id) {
+            return Err(ControlStateError::Validation(format!(
+                "campaign {} missing objective {} in objective_ids",
+                campaign.id.as_str(),
+                objective.id.as_str()
+            )));
+        }
+    }
+
+    for campaign in state.campaigns.values() {
+        for objective_id in &campaign.objective_ids {
+            let objective = state.objectives.get(objective_id).ok_or_else(|| {
+                ControlStateError::Validation(format!(
+                    "campaign {} references missing objective {}",
+                    campaign.id.as_str(),
+                    objective_id.as_str()
+                ))
+            })?;
+            if objective.campaign_id != campaign.id {
+                return Err(ControlStateError::Validation(format!(
+                    "campaign {} references objective {} that belongs to campaign {}",
+                    campaign.id.as_str(),
+                    objective_id.as_str(),
+                    objective.campaign_id.as_str()
+                )));
+            }
+        }
+    }
+
+    for campaign in state.campaigns.values() {
+        let objectives = state
+            .objectives
+            .values()
+            .filter(|objective| objective.campaign_id == campaign.id)
+            .cloned()
+            .collect::<Vec<_>>();
+        validate_prerequisite_graph(&objectives)?;
+    }
+
     Ok(())
 }
 
@@ -568,6 +682,47 @@ impl<S: TransactionalStateStore, A: ArtifactStorage> ControlPlane<S, A> {
         self.state_store.apply_transaction(&tx)
     }
 
+    pub fn record_campaign(
+        &mut self,
+        campaign: Campaign,
+        correlation_id: Option<CorrelationId>,
+    ) -> Result<(), ControlStateError> {
+        let tx = ControlTransaction::new(
+            vec![ControlMutation::UpsertCampaign(campaign)],
+            correlation_id,
+            now_secs(),
+        )?;
+        self.state_store.apply_transaction(&tx)
+    }
+
+    pub fn record_objective(
+        &mut self,
+        objective: Objective,
+        correlation_id: Option<CorrelationId>,
+    ) -> Result<(), ControlStateError> {
+        let tx = ControlTransaction::new(
+            vec![ControlMutation::UpsertObjective(objective)],
+            correlation_id,
+            now_secs(),
+        )?;
+        self.state_store.apply_transaction(&tx)
+    }
+
+    pub fn record_campaign_snapshot(
+        &mut self,
+        campaign: Campaign,
+        objectives: Vec<Objective>,
+        correlation_id: Option<CorrelationId>,
+    ) -> Result<(), ControlStateError> {
+        let mut mutations = Vec::with_capacity(objectives.len().saturating_add(1));
+        mutations.push(ControlMutation::UpsertCampaign(campaign));
+        for objective in objectives {
+            mutations.push(ControlMutation::UpsertObjective(objective));
+        }
+        let tx = ControlTransaction::new(mutations, correlation_id, now_secs())?;
+        self.state_store.apply_transaction(&tx)
+    }
+
     pub fn archive_transcript(
         &mut self,
         run_id: RunId,
@@ -726,8 +881,9 @@ impl<S: TransactionalStateStore, A: ArtifactStorage> ControlPlane<S, A> {
 
 fn encode_control_state(state: &ControlState) -> String {
     let mut out = String::new();
-    out.push_str(CONTROL_STATE_HEADER);
+    out.push_str(CONTROL_STATE_HEADER_V2);
     out.push('\n');
+    out.push_str(&format!("meta|schema_version|{}\n", state.schema_version));
 
     for run in state.runs.values() {
         out.push_str(&format!(
@@ -798,6 +954,37 @@ fn encode_control_state(state: &ControlState) -> String {
         ));
     }
 
+    for campaign in state.campaigns.values() {
+        out.push_str(&format!(
+            "campaign|{}|{}|{}|{}|{}|{}|{}\n",
+            campaign.id.as_str(),
+            encode_hex(&campaign.name),
+            encode_hex(&campaign.description),
+            campaign.created_at,
+            campaign_status_to_str(campaign.status),
+            encode_objective_ids(&campaign.objective_ids),
+            encode_metadata_map_opt(campaign.metadata.as_ref()),
+        ));
+    }
+
+    for objective in state.objectives.values() {
+        out.push_str(&format!(
+            "objective|{}|{}|{}|{}|{}|{}|{}|{}|{}|{}|{}|{}\n",
+            objective.id.as_str(),
+            objective.campaign_id.as_str(),
+            encode_hex(&objective.name),
+            encode_hex(&objective.description),
+            objective_status_to_str(objective.status),
+            encode_objective_ids(&objective.prerequisites),
+            encode_predicates(&objective.success_criteria),
+            encode_predicates(&objective.failure_criteria),
+            risk_level_to_str(objective.risk_level),
+            encode_opt_u32(objective.noise_budget),
+            objective.created_at,
+            objective.updated_at,
+        ));
+    }
+
     let tx_ids = state
         .applied_transactions
         .iter()
@@ -814,14 +1001,24 @@ fn decode_control_state(input: &str) -> Result<ControlState, ControlStateError> 
     let Some(header) = lines.next() else {
         return Err(ControlStateError::Parse("empty control state".to_string()));
     };
-    if header != CONTROL_STATE_HEADER {
+    let is_v1 = header == CONTROL_STATE_HEADER_V1;
+    let is_v2 = header == CONTROL_STATE_HEADER_V2;
+    if !is_v1 && !is_v2 {
         return Err(ControlStateError::Parse(format!(
             "unsupported control state header '{}'",
             header
         )));
     }
 
-    let mut state = ControlState::default();
+    let mut state = if is_v1 {
+        ControlState {
+            schema_version: 1,
+            ..ControlState::default()
+        }
+    } else {
+        ControlState::default()
+    };
+    let mut saw_schema_meta = false;
 
     for line in lines {
         if line.trim().is_empty() {
@@ -829,6 +1026,26 @@ fn decode_control_state(input: &str) -> Result<ControlState, ControlStateError> 
         }
         let parts: Vec<&str> = line.split('|').collect();
         match parts.first().copied().unwrap_or_default() {
+            "meta" => {
+                if parts.len() != 3 {
+                    return Err(ControlStateError::Parse(format!(
+                        "invalid meta record '{}'",
+                        line
+                    )));
+                }
+                match parts[1] {
+                    "schema_version" => {
+                        state.schema_version = parse_u32(parts[2])?;
+                        saw_schema_meta = true;
+                    }
+                    other => {
+                        return Err(ControlStateError::Parse(format!(
+                            "unknown meta key '{}'",
+                            other
+                        )));
+                    }
+                }
+            }
             "run" => {
                 if parts.len() != 13 {
                     return Err(ControlStateError::Parse(format!(
@@ -918,6 +1135,47 @@ fn decode_control_state(input: &str) -> Result<ControlState, ControlStateError> 
                 };
                 state.artifacts.insert(artifact.id, artifact);
             }
+            "campaign" => {
+                if parts.len() != 8 {
+                    return Err(ControlStateError::Parse(format!(
+                        "invalid campaign record '{}'",
+                        line
+                    )));
+                }
+                let campaign = Campaign {
+                    id: CampaignId::parse(parts[1])?,
+                    name: decode_hex(parts[2])?,
+                    description: decode_hex(parts[3])?,
+                    created_at: parse_u64(parts[4])?,
+                    status: parse_campaign_status(parts[5])?,
+                    objective_ids: parse_objective_ids(parts[6])?,
+                    metadata: decode_metadata_map_opt(parts[7])?,
+                };
+                state.campaigns.insert(campaign.id.clone(), campaign);
+            }
+            "objective" => {
+                if parts.len() != 13 {
+                    return Err(ControlStateError::Parse(format!(
+                        "invalid objective record '{}'",
+                        line
+                    )));
+                }
+                let objective = Objective {
+                    id: ObjectiveId::parse(parts[1])?,
+                    campaign_id: CampaignId::parse(parts[2])?,
+                    name: decode_hex(parts[3])?,
+                    description: decode_hex(parts[4])?,
+                    status: parse_objective_status(parts[5])?,
+                    prerequisites: parse_objective_ids(parts[6])?,
+                    success_criteria: decode_predicates(parts[7])?,
+                    failure_criteria: decode_predicates(parts[8])?,
+                    risk_level: parse_risk_level(parts[9])?,
+                    noise_budget: parse_opt_u32(parts[10])?,
+                    created_at: parse_u64(parts[11])?,
+                    updated_at: parse_u64(parts[12])?,
+                };
+                state.objectives.insert(objective.id.clone(), objective);
+            }
             "txids" => {
                 if parts.len() != 2 {
                     return Err(ControlStateError::Parse(format!(
@@ -938,6 +1196,10 @@ fn decode_control_state(input: &str) -> Result<ControlState, ControlStateError> 
         }
     }
 
+    if is_v2 && !saw_schema_meta {
+        state.schema_version = CONTROL_STATE_SCHEMA_VERSION;
+    }
+    validate_campaign_graph_integrity(&state)?;
     Ok(state)
 }
 
@@ -951,6 +1213,13 @@ fn parse_u32(input: &str) -> Result<u32, ControlStateError> {
     input
         .parse::<u32>()
         .map_err(|_| ControlStateError::Parse(format!("invalid u32 '{}'", input)))
+}
+
+fn parse_opt_u32(input: &str) -> Result<Option<u32>, ControlStateError> {
+    if input == "-" {
+        return Ok(None);
+    }
+    parse_u32(input).map(Some)
 }
 
 fn parse_opt_u64(input: &str) -> Result<Option<u64>, ControlStateError> {
@@ -977,6 +1246,12 @@ fn encode_opt_u64(value: Option<u64>) -> String {
         .unwrap_or_else(|| "-".to_string())
 }
 
+fn encode_opt_u32(value: Option<u32>) -> String {
+    value
+        .map(|v| v.to_string())
+        .unwrap_or_else(|| "-".to_string())
+}
+
 fn encode_opt_string(value: Option<&str>) -> String {
     value.map(encode_hex).unwrap_or_else(|| "-".to_string())
 }
@@ -986,6 +1261,93 @@ fn decode_opt_string(value: &str) -> Result<Option<String>, ControlStateError> {
         return Ok(None);
     }
     decode_hex(value).map(Some)
+}
+
+fn encode_objective_ids(ids: &[ObjectiveId]) -> String {
+    ids.iter()
+        .map(|id| id.as_str().to_string())
+        .collect::<Vec<_>>()
+        .join(",")
+}
+
+fn parse_objective_ids(input: &str) -> Result<Vec<ObjectiveId>, ControlStateError> {
+    if input.trim().is_empty() {
+        return Ok(Vec::new());
+    }
+    input
+        .split(',')
+        .filter(|part| !part.trim().is_empty())
+        .map(ObjectiveId::parse)
+        .collect::<Result<Vec<_>, _>>()
+        .map_err(ControlStateError::from)
+}
+
+fn encode_predicates(predicates: &[Predicate]) -> String {
+    predicates
+        .iter()
+        .map(|predicate| encode_hex_bytes(&predicate.to_wire_bytes()))
+        .collect::<Vec<_>>()
+        .join(",")
+}
+
+fn decode_predicates(input: &str) -> Result<Vec<Predicate>, ControlStateError> {
+    if input.trim().is_empty() {
+        return Ok(Vec::new());
+    }
+    input
+        .split(',')
+        .filter(|part| !part.trim().is_empty())
+        .map(|part| {
+            let bytes = decode_hex_bytes(part)?;
+            Predicate::from_wire_bytes(&bytes).map_err(ControlStateError::from)
+        })
+        .collect()
+}
+
+fn encode_metadata_map_opt(value: Option<&BTreeMap<String, MetadataValue>>) -> String {
+    let Some(map) = value else {
+        return "-".to_string();
+    };
+    let entries = map
+        .iter()
+        .map(|(key, metadata)| {
+            format!(
+                "{}:{}",
+                encode_hex(key),
+                encode_hex_bytes(&metadata.to_wire_bytes())
+            )
+        })
+        .collect::<Vec<_>>()
+        .join(",");
+    encode_hex(&entries)
+}
+
+fn decode_metadata_map_opt(
+    value: &str,
+) -> Result<Option<BTreeMap<String, MetadataValue>>, ControlStateError> {
+    if value == "-" {
+        return Ok(None);
+    }
+    let decoded = decode_hex(value)?;
+    if decoded.trim().is_empty() {
+        return Ok(Some(BTreeMap::new()));
+    }
+    let mut map = BTreeMap::new();
+    for entry in decoded.split(',').filter(|part| !part.trim().is_empty()) {
+        let (raw_key, raw_value) = entry.split_once(':').ok_or_else(|| {
+            ControlStateError::Parse(format!("invalid campaign metadata entry '{}'", entry))
+        })?;
+        let key = decode_hex(raw_key)?;
+        let value_bytes = decode_hex_bytes(raw_value)?;
+        let metadata_value = MetadataValue::from_wire_bytes(&value_bytes)?;
+        if map.insert(key.clone(), metadata_value).is_some() {
+            return Err(ControlStateError::Parse(format!(
+                "duplicate campaign metadata key '{}'",
+                key
+            )));
+        }
+    }
+    Ok(Some(map))
 }
 
 fn encode_hex(input: &str) -> String {
@@ -1012,6 +1374,31 @@ fn decode_hex(input: &str) -> Result<String, ControlStateError> {
     }
     String::from_utf8(bytes)
         .map_err(|_| ControlStateError::Parse("invalid utf-8 in hex".to_string()))
+}
+
+fn encode_hex_bytes(bytes: &[u8]) -> String {
+    let mut out = String::with_capacity(bytes.len() * 2);
+    for byte in bytes {
+        out.push(nibble_to_hex(byte >> 4));
+        out.push(nibble_to_hex(byte & 0x0f));
+    }
+    out
+}
+
+fn decode_hex_bytes(input: &str) -> Result<Vec<u8>, ControlStateError> {
+    if input.len() % 2 != 0 {
+        return Err(ControlStateError::Parse("invalid hex length".to_string()));
+    }
+    let mut bytes = Vec::with_capacity(input.len() / 2);
+    let data = input.as_bytes();
+    let mut i = 0;
+    while i < data.len() {
+        let hi = hex_to_nibble(data[i])?;
+        let lo = hex_to_nibble(data[i + 1])?;
+        bytes.push((hi << 4) | lo);
+        i += 2;
+    }
+    Ok(bytes)
 }
 
 fn nibble_to_hex(value: u8) -> char {
@@ -1123,9 +1510,61 @@ fn parse_artifact_kind(kind: &str) -> Result<ArtifactKind, ControlStateError> {
     }
 }
 
+fn campaign_status_to_str(status: CampaignStatus) -> &'static str {
+    status.as_str()
+}
+
+fn parse_campaign_status(status: &str) -> Result<CampaignStatus, ControlStateError> {
+    match status {
+        "active" => Ok(CampaignStatus::Active),
+        "paused" => Ok(CampaignStatus::Paused),
+        "completed" => Ok(CampaignStatus::Completed),
+        "failed" => Ok(CampaignStatus::Failed),
+        _ => Err(ControlStateError::Parse(format!(
+            "invalid campaign status '{}'",
+            status
+        ))),
+    }
+}
+
+fn objective_status_to_str(status: ObjectiveStatus) -> &'static str {
+    status.as_str()
+}
+
+fn parse_objective_status(status: &str) -> Result<ObjectiveStatus, ControlStateError> {
+    match status {
+        "pending" => Ok(ObjectiveStatus::Pending),
+        "eligible" => Ok(ObjectiveStatus::Eligible),
+        "in_progress" => Ok(ObjectiveStatus::InProgress),
+        "achieved" => Ok(ObjectiveStatus::Achieved),
+        "failed" => Ok(ObjectiveStatus::Failed),
+        _ => Err(ControlStateError::Parse(format!(
+            "invalid objective status '{}'",
+            status
+        ))),
+    }
+}
+
+fn risk_level_to_str(level: RiskLevel) -> &'static str {
+    level.as_str()
+}
+
+fn parse_risk_level(level: &str) -> Result<RiskLevel, ControlStateError> {
+    match level {
+        "low" => Ok(RiskLevel::Low),
+        "medium" => Ok(RiskLevel::Medium),
+        "high" => Ok(RiskLevel::High),
+        _ => Err(ControlStateError::Parse(format!(
+            "invalid risk level '{}'",
+            level
+        ))),
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::campaign::SessionPrivilegeLevel;
 
     fn build_run(now: u64) -> Run {
         Run::new_at(
@@ -1321,6 +1760,171 @@ mod tests {
                 .read_artifact(&artifact.locator)
                 .expect("read artifact");
             assert_eq!(bytes, b"id\nuid=0(root)");
+        }
+
+        let _ = std::fs::remove_dir_all(base);
+    }
+
+    #[test]
+    fn campaign_snapshot_round_trip_preserves_state_and_schema_version() {
+        let campaign_id =
+            CampaignId::parse("de305d54-75b4-431b-adb2-eb6b9e546014").expect("campaign id");
+        let objective_id =
+            ObjectiveId::parse("0f8fad5b-d9cb-469f-a165-70867728950e").expect("objective id");
+        let mut metadata = BTreeMap::new();
+        metadata.insert(
+            "owner".to_string(),
+            MetadataValue::Text("purple-team".to_string()),
+        );
+        metadata.insert("budget".to_string(), MetadataValue::Integer(10));
+
+        let mut campaign = Campaign::new_at(
+            campaign_id.clone(),
+            "operation-rain",
+            "exercise",
+            100,
+            Some(metadata),
+        )
+        .expect("campaign");
+        campaign.add_objective(objective_id.clone());
+
+        let mut objective = Objective::new_at(
+            objective_id,
+            campaign_id,
+            "get root",
+            "escalate session",
+            vec![],
+            vec![Predicate::SessionPrivilege {
+                level: SessionPrivilegeLevel::Root,
+            }],
+            vec![Predicate::FindingExists {
+                finding_type: "detection".to_string(),
+            }],
+            RiskLevel::High,
+            Some(7),
+            100,
+        )
+        .expect("objective");
+        objective.status = ObjectiveStatus::InProgress;
+        objective.updated_at = 120;
+
+        let mut state = ControlState::default();
+        state
+            .campaigns
+            .insert(campaign.id.clone(), campaign.clone());
+        state
+            .objectives
+            .insert(objective.id.clone(), objective.clone());
+        state.schema_version = CONTROL_STATE_SCHEMA_VERSION;
+
+        let encoded = encode_control_state(&state);
+        let decoded = decode_control_state(&encoded).expect("decode");
+        assert_eq!(decoded.schema_version, CONTROL_STATE_SCHEMA_VERSION);
+        assert_eq!(decoded.campaigns.get(&campaign.id), Some(&campaign));
+        assert_eq!(decoded.objectives.get(&objective.id), Some(&objective));
+    }
+
+    #[test]
+    fn campaign_snapshot_transaction_is_atomic_on_validation_failure() {
+        let mut plane = ControlPlane::new(
+            InMemoryTransactionalStateStore::default(),
+            InMemoryArtifactStorage::default(),
+        );
+        let campaign_a =
+            CampaignId::parse("de305d54-75b4-431b-adb2-eb6b9e546014").expect("campaign id");
+        let campaign_b =
+            CampaignId::parse("9b2f4d6a-3aa4-41ba-91ed-6308a58186a1").expect("campaign id");
+        let objective_id =
+            ObjectiveId::parse("0f8fad5b-d9cb-469f-a165-70867728950e").expect("objective id");
+
+        let campaign = Campaign::new_at(campaign_a, "op", "desc", 1, None).expect("campaign");
+        let objective = Objective::new_at(
+            objective_id,
+            campaign_b,
+            "bad objective",
+            "wrong campaign id",
+            vec![],
+            vec![Predicate::RunSucceeded {
+                module_name: "exploit/linux/example".to_string(),
+            }],
+            vec![],
+            RiskLevel::Low,
+            None,
+            1,
+        )
+        .expect("objective");
+
+        let err = plane
+            .record_campaign_snapshot(campaign, vec![objective], None)
+            .expect_err("transaction should fail");
+        assert!(
+            err.to_string().contains("references missing campaign"),
+            "unexpected error: {err}"
+        );
+
+        let state = plane.state().expect("state");
+        assert!(state.campaigns.is_empty());
+        assert!(state.objectives.is_empty());
+    }
+
+    #[test]
+    fn file_store_recovers_campaign_and_objective_snapshot_after_restart() {
+        let base = std::env::temp_dir().join(format!("moonlight-campaign-state-{}", Id::next().0));
+        let log_path = base.join("control.log");
+
+        let campaign_id =
+            CampaignId::parse("de305d54-75b4-431b-adb2-eb6b9e546014").expect("campaign id");
+        let objective_id =
+            ObjectiveId::parse("0f8fad5b-d9cb-469f-a165-70867728950e").expect("objective id");
+
+        {
+            let mut plane = ControlPlane::new(
+                FileTransactionalStateStore::new(&log_path).expect("state store"),
+                InMemoryArtifactStorage::default(),
+            );
+
+            let mut campaign =
+                Campaign::new_at(campaign_id.clone(), "op", "desc", 10, None).expect("campaign");
+            campaign.add_objective(objective_id.clone());
+            let mut objective = Objective::new_at(
+                objective_id.clone(),
+                campaign_id.clone(),
+                "initial access",
+                "obtain session",
+                vec![],
+                vec![Predicate::FindingExists {
+                    finding_type: "credential".to_string(),
+                }],
+                vec![],
+                RiskLevel::Medium,
+                None,
+                10,
+            )
+            .expect("objective");
+            objective.status = ObjectiveStatus::Eligible;
+            objective.updated_at = 15;
+
+            plane
+                .record_campaign_snapshot(campaign, vec![objective], None)
+                .expect("record snapshot");
+        }
+
+        {
+            let mut recovered = ControlPlane::new(
+                FileTransactionalStateStore::new(&log_path).expect("reload store"),
+                InMemoryArtifactStorage::default(),
+            );
+            let state = recovered.state().expect("state");
+            assert_eq!(state.schema_version, CONTROL_STATE_SCHEMA_VERSION);
+            assert!(state.campaigns.contains_key(&campaign_id));
+            assert!(state.objectives.contains_key(&objective_id));
+            assert_eq!(
+                state
+                    .objectives
+                    .get(&objective_id)
+                    .map(|value| value.status),
+                Some(ObjectiveStatus::Eligible)
+            );
         }
 
         let _ = std::fs::remove_dir_all(base);

--- a/core/core/src/control.rs
+++ b/core/core/src/control.rs
@@ -17,7 +17,7 @@ use crate::time::now_secs;
 
 const CONTROL_STATE_HEADER_V1: &str = "moonlight-control-state:v1";
 const CONTROL_STATE_HEADER_V2: &str = "moonlight-control-state:v2";
-const CONTROL_STATE_SCHEMA_VERSION: u32 = 4;
+const CONTROL_STATE_SCHEMA_VERSION: u32 = 5;
 const CONTROL_COMMIT_LOG_HEADER: &str = "moonlight-control-commit-log:v1";
 
 #[derive(Debug)]

--- a/core/core/src/lib.rs
+++ b/core/core/src/lib.rs
@@ -1,3 +1,4 @@
+pub mod campaign;
 pub mod control;
 pub mod domain;
 pub mod error;

--- a/core/core/src/orchestrator.rs
+++ b/core/core/src/orchestrator.rs
@@ -1,4 +1,4 @@
-use std::collections::{BTreeMap, VecDeque};
+use std::collections::{BTreeMap, BTreeSet, VecDeque};
 use std::fmt;
 use std::io::Write;
 use std::path::{Path, PathBuf};
@@ -10,6 +10,7 @@ use crate::campaign::{
     ObjectiveIngestionDispatcher, ObjectiveIngestionEvent, ObjectiveReevaluationTrigger,
     ObjectiveStatus, PredicateSnapshot, RiskLevel,
 };
+use crate::control::ControlState;
 use crate::domain::{
     ArtifactId, CorrelationId, DomainError, EventId, FindingId, ModuleVersionId, Run, RunId,
     RunState, SessionId, TargetId, Task, TaskId, TaskState, WorkspaceId,
@@ -415,6 +416,45 @@ pub struct ReconstructedTask {
     pub idempotency_key: String,
     pub error: Option<String>,
     pub deduplicated_from: Option<TaskId>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ReplayDiagnostic {
+    pub code: &'static str,
+    pub message: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ReplayedObjective {
+    pub objective_id: ObjectiveId,
+    pub name: Option<String>,
+    pub risk_level: Option<RiskLevel>,
+    pub status: ObjectiveStatus,
+    pub prerequisites: BTreeSet<ObjectiveId>,
+    pub evaluation_count: u64,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ReconstructedCampaign {
+    pub campaign_id: CampaignId,
+    pub correlation_id: CorrelationId,
+    pub sequence_high_watermark: u64,
+    pub name: Option<String>,
+    pub status: CampaignStatus,
+    pub objective_ids: BTreeSet<ObjectiveId>,
+    pub objectives: BTreeMap<ObjectiveId, ReplayedObjective>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CampaignReplayReport {
+    pub campaign: Option<ReconstructedCampaign>,
+    pub diagnostics: Vec<ReplayDiagnostic>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CampaignReplayConsistency {
+    pub report: CampaignReplayReport,
+    pub consistent: bool,
 }
 
 pub trait AuditLogStore {
@@ -1779,6 +1819,33 @@ impl<S: SnapshotStore, A: AuditLogStore> ObservableExecutionOrchestrator<S, A> {
         Ok(reconstruct_run_from_events(&events, run_id))
     }
 
+    pub fn reconstruct_campaign_from_history(
+        &mut self,
+        campaign_id: &CampaignId,
+    ) -> Result<CampaignReplayReport, OrchestratorError> {
+        let events = self.audit_store.load_events()?;
+        Ok(reconstruct_campaign_from_events(&events, campaign_id))
+    }
+
+    pub fn replay_campaign_consistency(
+        &mut self,
+        campaign_id: &CampaignId,
+        snapshot: &ControlState,
+    ) -> Result<CampaignReplayConsistency, OrchestratorError> {
+        let report = self.reconstruct_campaign_from_history(campaign_id)?;
+        let diagnostics = compare_campaign_replay_to_snapshot(&report, snapshot, campaign_id);
+        let mut merged = report.diagnostics.clone();
+        merged.extend(diagnostics);
+        let consistent = merged.is_empty();
+        Ok(CampaignReplayConsistency {
+            report: CampaignReplayReport {
+                campaign: report.campaign,
+                diagnostics: merged,
+            },
+            consistent,
+        })
+    }
+
     pub fn run_state(&self, run_id: RunId) -> Option<RunState> {
         self.inner.run_state(run_id)
     }
@@ -2974,6 +3041,399 @@ fn reconstruct_run_from_events(events: &[AuditEvent], run_id: RunId) -> Option<R
     }
 
     reconstructed
+}
+
+fn reconstruct_campaign_from_events(
+    events: &[AuditEvent],
+    campaign_id: &CampaignId,
+) -> CampaignReplayReport {
+    let mut diagnostics = Vec::<ReplayDiagnostic>::new();
+    let mut reconstructed: Option<ReconstructedCampaign> = None;
+
+    for event in events {
+        let AuditEventPayload::Campaign(campaign_event) = &event.payload else {
+            continue;
+        };
+        let payload_campaign_id = campaign_event.payload.campaign_id();
+        if payload_campaign_id != campaign_id {
+            continue;
+        }
+
+        let Some(campaign) = reconstructed.as_mut() else {
+            reconstructed = Some(ReconstructedCampaign {
+                campaign_id: campaign_id.clone(),
+                correlation_id: event.correlation_id,
+                sequence_high_watermark: 0,
+                name: None,
+                status: CampaignStatus::Active,
+                objective_ids: BTreeSet::new(),
+                objectives: BTreeMap::new(),
+            });
+            continue;
+        };
+
+        if campaign.correlation_id != event.correlation_id {
+            diagnostics.push(ReplayDiagnostic {
+                code: "ML-REPLAY-0001",
+                message: format!(
+                    "campaign {} has mixed lineage correlations {} and {}",
+                    campaign_id.as_str(),
+                    campaign.correlation_id.0 .0,
+                    event.correlation_id.0 .0
+                ),
+            });
+        }
+    }
+
+    for event in events {
+        let AuditEventPayload::Campaign(campaign_event) = &event.payload else {
+            continue;
+        };
+        let payload_campaign_id = campaign_event.payload.campaign_id();
+        if payload_campaign_id != campaign_id {
+            continue;
+        }
+        let Some(campaign) = reconstructed.as_mut() else {
+            continue;
+        };
+
+        let expected_next = campaign.sequence_high_watermark.saturating_add(1);
+        if campaign_event.sequence != expected_next {
+            diagnostics.push(ReplayDiagnostic {
+                code: "ML-REPLAY-0002",
+                message: format!(
+                    "campaign {} sequence mismatch: expected {}, found {}",
+                    campaign_id.as_str(),
+                    expected_next,
+                    campaign_event.sequence
+                ),
+            });
+        }
+        campaign.sequence_high_watermark = campaign_event.sequence;
+
+        match &campaign_event.payload {
+            CampaignPayload::CampaignCreated { name, .. } => {
+                if campaign.name.is_some() {
+                    diagnostics.push(ReplayDiagnostic {
+                        code: "ML-REPLAY-0003",
+                        message: format!(
+                            "campaign {} contains duplicate CampaignCreated event",
+                            campaign_id.as_str()
+                        ),
+                    });
+                }
+                campaign.name = Some(name.clone());
+                campaign.status = CampaignStatus::Active;
+            }
+            CampaignPayload::CampaignStatusChanged { from, to, .. } => {
+                if campaign.status != *from {
+                    diagnostics.push(ReplayDiagnostic {
+                        code: "ML-REPLAY-0004",
+                        message: format!(
+                            "campaign {} status mismatch during replay: event from={} but current={}",
+                            campaign_id.as_str(),
+                            from.as_str(),
+                            campaign.status.as_str()
+                        ),
+                    });
+                }
+                if !campaign.status.can_transition_to(*to) {
+                    diagnostics.push(ReplayDiagnostic {
+                        code: "ML-REPLAY-0005",
+                        message: format!(
+                            "campaign {} invalid transition during replay: {} -> {}",
+                            campaign_id.as_str(),
+                            campaign.status.as_str(),
+                            to.as_str()
+                        ),
+                    });
+                }
+                campaign.status = *to;
+            }
+            CampaignPayload::ObjectiveCreated {
+                objective_id,
+                name,
+                risk_level,
+                ..
+            } => {
+                campaign.objective_ids.insert(objective_id.clone());
+                let entry = campaign
+                    .objectives
+                    .entry(objective_id.clone())
+                    .or_insert_with(|| ReplayedObjective {
+                        objective_id: objective_id.clone(),
+                        name: None,
+                        risk_level: None,
+                        status: ObjectiveStatus::Pending,
+                        prerequisites: BTreeSet::new(),
+                        evaluation_count: 0,
+                    });
+                entry.name = Some(name.clone());
+                entry.risk_level = Some(*risk_level);
+            }
+            CampaignPayload::ObjectivePrereqLinked {
+                objective_id,
+                prerequisite_id,
+                ..
+            } => {
+                campaign.objective_ids.insert(objective_id.clone());
+                campaign.objective_ids.insert(prerequisite_id.clone());
+                let entry = campaign
+                    .objectives
+                    .entry(objective_id.clone())
+                    .or_insert_with(|| ReplayedObjective {
+                        objective_id: objective_id.clone(),
+                        name: None,
+                        risk_level: None,
+                        status: ObjectiveStatus::Pending,
+                        prerequisites: BTreeSet::new(),
+                        evaluation_count: 0,
+                    });
+                entry.prerequisites.insert(prerequisite_id.clone());
+            }
+            CampaignPayload::ObjectiveStatusChanged {
+                objective_id,
+                from,
+                to,
+                ..
+            } => {
+                let entry = campaign
+                    .objectives
+                    .entry(objective_id.clone())
+                    .or_insert_with(|| ReplayedObjective {
+                        objective_id: objective_id.clone(),
+                        name: None,
+                        risk_level: None,
+                        status: ObjectiveStatus::Pending,
+                        prerequisites: BTreeSet::new(),
+                        evaluation_count: 0,
+                    });
+                if entry.status != *from {
+                    diagnostics.push(ReplayDiagnostic {
+                        code: "ML-REPLAY-0006",
+                        message: format!(
+                            "objective {} status mismatch during replay: event from={} current={}",
+                            objective_id.as_str(),
+                            from.as_str(),
+                            entry.status.as_str()
+                        ),
+                    });
+                }
+                if !entry.status.can_transition_to(*to) {
+                    diagnostics.push(ReplayDiagnostic {
+                        code: "ML-REPLAY-0007",
+                        message: format!(
+                            "objective {} invalid transition during replay: {} -> {}",
+                            objective_id.as_str(),
+                            entry.status.as_str(),
+                            to.as_str()
+                        ),
+                    });
+                }
+                entry.status = *to;
+                campaign.objective_ids.insert(objective_id.clone());
+            }
+            CampaignPayload::ObjectiveEvaluated {
+                objective_id,
+                prerequisites_satisfied,
+                success_criteria_satisfied,
+                failure_criteria_satisfied,
+                resulting_status,
+                ..
+            } => {
+                let entry = campaign
+                    .objectives
+                    .entry(objective_id.clone())
+                    .or_insert_with(|| ReplayedObjective {
+                        objective_id: objective_id.clone(),
+                        name: None,
+                        risk_level: None,
+                        status: ObjectiveStatus::Pending,
+                        prerequisites: BTreeSet::new(),
+                        evaluation_count: 0,
+                    });
+                entry.evaluation_count = entry.evaluation_count.saturating_add(1);
+
+                if entry.status != *resulting_status {
+                    diagnostics.push(ReplayDiagnostic {
+                        code: "ML-REPLAY-0008",
+                        message: format!(
+                            "objective {} evaluated status mismatch: replay={} event={}",
+                            objective_id.as_str(),
+                            entry.status.as_str(),
+                            resulting_status.as_str()
+                        ),
+                    });
+                }
+                if *resulting_status == ObjectiveStatus::Eligible && !*prerequisites_satisfied {
+                    diagnostics.push(ReplayDiagnostic {
+                        code: "ML-REPLAY-0009",
+                        message: format!(
+                            "objective {} marked eligible without prerequisite satisfaction",
+                            objective_id.as_str()
+                        ),
+                    });
+                }
+                if *resulting_status == ObjectiveStatus::Achieved && !*success_criteria_satisfied {
+                    diagnostics.push(ReplayDiagnostic {
+                        code: "ML-REPLAY-0010",
+                        message: format!(
+                            "objective {} marked achieved without success criteria",
+                            objective_id.as_str()
+                        ),
+                    });
+                }
+                if *resulting_status == ObjectiveStatus::Failed && !*failure_criteria_satisfied {
+                    diagnostics.push(ReplayDiagnostic {
+                        code: "ML-REPLAY-0011",
+                        message: format!(
+                            "objective {} marked failed without failure criteria",
+                            objective_id.as_str()
+                        ),
+                    });
+                }
+
+                campaign.objective_ids.insert(objective_id.clone());
+            }
+        }
+    }
+
+    if reconstructed.is_none() {
+        diagnostics.push(ReplayDiagnostic {
+            code: "ML-REPLAY-0012",
+            message: format!(
+                "campaign {} not found in audit event history",
+                campaign_id.as_str()
+            ),
+        });
+    }
+
+    CampaignReplayReport {
+        campaign: reconstructed,
+        diagnostics,
+    }
+}
+
+fn compare_campaign_replay_to_snapshot(
+    report: &CampaignReplayReport,
+    snapshot: &ControlState,
+    campaign_id: &CampaignId,
+) -> Vec<ReplayDiagnostic> {
+    let mut diagnostics = Vec::new();
+    let Some(replayed) = report.campaign.as_ref() else {
+        diagnostics.push(ReplayDiagnostic {
+            code: "ML-REPLAY-0013",
+            message: format!(
+                "cannot compare snapshot for campaign {} because replay produced no campaign state",
+                campaign_id.as_str()
+            ),
+        });
+        return diagnostics;
+    };
+
+    let Some(snapshot_campaign) = snapshot.campaigns.get(campaign_id) else {
+        diagnostics.push(ReplayDiagnostic {
+            code: "ML-REPLAY-0014",
+            message: format!(
+                "snapshot missing campaign {} while replay produced one",
+                campaign_id.as_str()
+            ),
+        });
+        return diagnostics;
+    };
+
+    if replayed.status != snapshot_campaign.status {
+        diagnostics.push(ReplayDiagnostic {
+            code: "ML-REPLAY-0015",
+            message: format!(
+                "campaign {} status mismatch replay={} snapshot={}",
+                campaign_id.as_str(),
+                replayed.status.as_str(),
+                snapshot_campaign.status.as_str()
+            ),
+        });
+    }
+
+    let snapshot_objective_ids = snapshot_campaign
+        .objective_ids
+        .iter()
+        .cloned()
+        .collect::<BTreeSet<_>>();
+    if replayed.objective_ids != snapshot_objective_ids {
+        diagnostics.push(ReplayDiagnostic {
+            code: "ML-REPLAY-0016",
+            message: format!(
+                "campaign {} objective id set mismatch replay={} snapshot={}",
+                campaign_id.as_str(),
+                replayed.objective_ids.len(),
+                snapshot_objective_ids.len()
+            ),
+        });
+    }
+
+    for objective_id in &replayed.objective_ids {
+        let Some(snapshot_objective) = snapshot.objectives.get(objective_id) else {
+            diagnostics.push(ReplayDiagnostic {
+                code: "ML-REPLAY-0017",
+                message: format!(
+                    "snapshot missing objective {} present in replay for campaign {}",
+                    objective_id.as_str(),
+                    campaign_id.as_str()
+                ),
+            });
+            continue;
+        };
+        if snapshot_objective.campaign_id != *campaign_id {
+            diagnostics.push(ReplayDiagnostic {
+                code: "ML-REPLAY-0018",
+                message: format!(
+                    "snapshot objective {} belongs to campaign {} instead of {}",
+                    objective_id.as_str(),
+                    snapshot_objective.campaign_id.as_str(),
+                    campaign_id.as_str()
+                ),
+            });
+        }
+        let Some(replayed_objective) = replayed.objectives.get(objective_id) else {
+            diagnostics.push(ReplayDiagnostic {
+                code: "ML-REPLAY-0019",
+                message: format!(
+                    "replay missing objective {} listed in replay objective id set",
+                    objective_id.as_str()
+                ),
+            });
+            continue;
+        };
+        if replayed_objective.status != snapshot_objective.status {
+            diagnostics.push(ReplayDiagnostic {
+                code: "ML-REPLAY-0020",
+                message: format!(
+                    "objective {} status mismatch replay={} snapshot={}",
+                    objective_id.as_str(),
+                    replayed_objective.status.as_str(),
+                    snapshot_objective.status.as_str()
+                ),
+            });
+        }
+    }
+
+    for objective in snapshot.objectives.values() {
+        if &objective.campaign_id != campaign_id {
+            continue;
+        }
+        if !replayed.objective_ids.contains(&objective.id) {
+            diagnostics.push(ReplayDiagnostic {
+                code: "ML-REPLAY-0021",
+                message: format!(
+                    "snapshot objective {} for campaign {} missing from replay",
+                    objective.id.as_str(),
+                    campaign_id.as_str()
+                ),
+            });
+        }
+    }
+
+    diagnostics
 }
 
 fn parse_u64(input: &str) -> Result<u64, OrchestratorError> {
@@ -4318,5 +4778,244 @@ mod tests {
             objectives[&objective_session].status,
             ObjectiveStatus::Achieved
         );
+    }
+
+    #[test]
+    fn campaign_cold_replay_reconstructs_identical_objective_outcomes() {
+        let snapshot_shared = Arc::new(Mutex::new(None));
+        let audit_shared = Arc::new(Mutex::new(Vec::<AuditEvent>::new()));
+        let campaign_id =
+            CampaignId::parse("de305d54-75b4-431b-adb2-eb6b9e546014").expect("campaign id");
+        let objective_id =
+            ObjectiveId::parse("0f8fad5b-d9cb-469f-a165-70867728950e").expect("objective id");
+
+        {
+            let snapshot_store = InMemorySnapshotStore::from_shared(Arc::clone(&snapshot_shared));
+            let audit_store = InMemoryAuditLogStore::from_shared(Arc::clone(&audit_shared));
+            let mut orchestrator =
+                ObservableExecutionOrchestrator::new(snapshot_store, audit_store).expect("new");
+
+            orchestrator
+                .record_campaign_events(
+                    vec![
+                        CampaignPayload::CampaignCreated {
+                            campaign_id: campaign_id.clone(),
+                            name: "operation".to_string(),
+                        },
+                        CampaignPayload::ObjectiveCreated {
+                            campaign_id: campaign_id.clone(),
+                            objective_id: objective_id.clone(),
+                            name: "escalate".to_string(),
+                            risk_level: RiskLevel::High,
+                        },
+                        CampaignPayload::ObjectiveStatusChanged {
+                            campaign_id: campaign_id.clone(),
+                            objective_id: objective_id.clone(),
+                            from: ObjectiveStatus::Pending,
+                            to: ObjectiveStatus::Eligible,
+                            reason: Some("prerequisites".to_string()),
+                        },
+                        CampaignPayload::ObjectiveStatusChanged {
+                            campaign_id: campaign_id.clone(),
+                            objective_id: objective_id.clone(),
+                            from: ObjectiveStatus::Eligible,
+                            to: ObjectiveStatus::InProgress,
+                            reason: Some("operator start".to_string()),
+                        },
+                        CampaignPayload::ObjectiveStatusChanged {
+                            campaign_id: campaign_id.clone(),
+                            objective_id: objective_id.clone(),
+                            from: ObjectiveStatus::InProgress,
+                            to: ObjectiveStatus::Achieved,
+                            reason: Some("criteria met".to_string()),
+                        },
+                        CampaignPayload::ObjectiveEvaluated {
+                            campaign_id: campaign_id.clone(),
+                            objective_id: objective_id.clone(),
+                            trigger: ObjectiveReevaluationTrigger::RunCompleted,
+                            prerequisites_satisfied: true,
+                            success_criteria_satisfied: true,
+                            failure_criteria_satisfied: false,
+                            resulting_status: ObjectiveStatus::Achieved,
+                        },
+                    ],
+                    None,
+                )
+                .expect("record campaign events");
+
+            let report = orchestrator
+                .reconstruct_campaign_from_history(&campaign_id)
+                .expect("replay");
+            assert!(report.diagnostics.is_empty(), "{:?}", report.diagnostics);
+            let campaign = report.campaign.expect("campaign");
+            assert_eq!(campaign.objective_ids.len(), 1);
+            assert_eq!(
+                campaign
+                    .objectives
+                    .get(&objective_id)
+                    .expect("objective")
+                    .status,
+                ObjectiveStatus::Achieved
+            );
+        }
+
+        let snapshot_store = InMemorySnapshotStore::from_shared(Arc::clone(&snapshot_shared));
+        let audit_store = InMemoryAuditLogStore::from_shared(Arc::clone(&audit_shared));
+        let mut recovered =
+            ObservableExecutionOrchestrator::new(snapshot_store, audit_store).expect("recover");
+        let replay = recovered
+            .reconstruct_campaign_from_history(&campaign_id)
+            .expect("replay");
+        assert!(replay.diagnostics.is_empty(), "{:?}", replay.diagnostics);
+        let campaign = replay.campaign.expect("campaign");
+        assert_eq!(
+            campaign
+                .objectives
+                .get(&objective_id)
+                .expect("objective")
+                .status,
+            ObjectiveStatus::Achieved
+        );
+    }
+
+    #[test]
+    fn campaign_replay_consistency_reports_snapshot_mismatches() {
+        let snapshot_store = InMemorySnapshotStore::default();
+        let audit_store = InMemoryAuditLogStore::default();
+        let mut orchestrator =
+            ObservableExecutionOrchestrator::new(snapshot_store, audit_store).expect("new");
+
+        let campaign_id =
+            CampaignId::parse("de305d54-75b4-431b-adb2-eb6b9e546014").expect("campaign id");
+        let objective_id =
+            ObjectiveId::parse("0f8fad5b-d9cb-469f-a165-70867728950e").expect("objective id");
+
+        orchestrator
+            .record_campaign_events(
+                vec![
+                    CampaignPayload::CampaignCreated {
+                        campaign_id: campaign_id.clone(),
+                        name: "operation".to_string(),
+                    },
+                    CampaignPayload::ObjectiveCreated {
+                        campaign_id: campaign_id.clone(),
+                        objective_id: objective_id.clone(),
+                        name: "escalate".to_string(),
+                        risk_level: RiskLevel::High,
+                    },
+                    CampaignPayload::ObjectiveEvaluated {
+                        campaign_id: campaign_id.clone(),
+                        objective_id: objective_id.clone(),
+                        trigger: ObjectiveReevaluationTrigger::ManualRequest,
+                        prerequisites_satisfied: true,
+                        success_criteria_satisfied: false,
+                        failure_criteria_satisfied: false,
+                        resulting_status: ObjectiveStatus::Pending,
+                    },
+                ],
+                None,
+            )
+            .expect("record events");
+
+        let mut snapshot = ControlState::default();
+        let mut campaign =
+            crate::campaign::Campaign::new_at(campaign_id.clone(), "operation", "", 1, None)
+                .expect("campaign");
+        campaign.add_objective(objective_id.clone());
+        let mut objective = crate::campaign::Objective::new_at(
+            objective_id,
+            campaign_id.clone(),
+            "escalate",
+            "",
+            vec![],
+            vec![crate::campaign::Predicate::RunSucceeded {
+                module_name: "exploit/linux/example".to_string(),
+            }],
+            vec![],
+            RiskLevel::High,
+            None,
+            1,
+        )
+        .expect("objective");
+        objective.status = ObjectiveStatus::Failed;
+        snapshot.campaigns.insert(campaign_id.clone(), campaign);
+        snapshot
+            .objectives
+            .insert(objective.id.clone(), objective.clone());
+
+        let consistency = orchestrator
+            .replay_campaign_consistency(&campaign_id, &snapshot)
+            .expect("consistency");
+        assert!(!consistency.consistent);
+        assert!(consistency
+            .report
+            .diagnostics
+            .iter()
+            .any(|diagnostic| diagnostic.code == "ML-REPLAY-0020"));
+    }
+
+    #[test]
+    fn campaign_replay_emits_diagnostics_for_invalid_event_sequences() {
+        let mut store = InMemoryAuditLogStore::default();
+        let campaign_id =
+            CampaignId::parse("de305d54-75b4-431b-adb2-eb6b9e546014").expect("campaign id");
+        let objective_id =
+            ObjectiveId::parse("0f8fad5b-d9cb-469f-a165-70867728950e").expect("objective id");
+        let correlation = CorrelationId::next();
+
+        store
+            .append_event(&AuditEvent {
+                id: EventId::next(),
+                correlation_id: correlation,
+                occurred_at: now_secs(),
+                payload: AuditEventPayload::Campaign(CampaignAuditEvent {
+                    sequence: 1,
+                    occurred_at: now_secs(),
+                    payload: CampaignPayload::CampaignCreated {
+                        campaign_id: campaign_id.clone(),
+                        name: "operation".to_string(),
+                    },
+                }),
+            })
+            .expect("append 1");
+        store
+            .append_event(&AuditEvent {
+                id: EventId::next(),
+                correlation_id: CorrelationId::next(),
+                occurred_at: now_secs(),
+                payload: AuditEventPayload::Campaign(CampaignAuditEvent {
+                    sequence: 3,
+                    occurred_at: now_secs(),
+                    payload: CampaignPayload::ObjectiveEvaluated {
+                        campaign_id: campaign_id.clone(),
+                        objective_id,
+                        trigger: ObjectiveReevaluationTrigger::ManualRequest,
+                        prerequisites_satisfied: false,
+                        success_criteria_satisfied: false,
+                        failure_criteria_satisfied: false,
+                        resulting_status: ObjectiveStatus::Achieved,
+                    },
+                }),
+            })
+            .expect("append 2");
+
+        let snapshot_store = InMemorySnapshotStore::default();
+        let mut orchestrator =
+            ObservableExecutionOrchestrator::new(snapshot_store, store).expect("new");
+        let report = orchestrator
+            .reconstruct_campaign_from_history(&campaign_id)
+            .expect("replay");
+        assert!(report
+            .diagnostics
+            .iter()
+            .any(|diagnostic| diagnostic.code == "ML-REPLAY-0001"));
+        assert!(report
+            .diagnostics
+            .iter()
+            .any(|diagnostic| diagnostic.code == "ML-REPLAY-0002"));
+        assert!(report
+            .diagnostics
+            .iter()
+            .any(|diagnostic| diagnostic.code == "ML-REPLAY-0010"));
     }
 }

--- a/core/core/src/orchestrator.rs
+++ b/core/core/src/orchestrator.rs
@@ -4,6 +4,10 @@ use std::io::Write;
 use std::path::{Path, PathBuf};
 use std::sync::{Arc, Mutex};
 
+use crate::campaign::{
+    CampaignEvent as CampaignAuditEvent, CampaignEventPayload as CampaignPayload, CampaignId,
+    CampaignStatus, ObjectiveId, ObjectiveReevaluationTrigger, ObjectiveStatus, RiskLevel,
+};
 use crate::domain::{
     CorrelationId, DomainError, EventId, ModuleVersionId, Run, RunId, RunState, SessionId,
     TargetId, Task, TaskId, TaskState, WorkspaceId,
@@ -274,6 +278,7 @@ pub enum AuditEventPayload {
     Task(TaskEvent),
     Session(SessionEvent),
     Module(ModuleEvent),
+    Campaign(CampaignAuditEvent),
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -1252,17 +1257,31 @@ pub struct ObservableExecutionOrchestrator<S: SnapshotStore, A: AuditLogStore> {
     inner: ExecutionOrchestrator<S>,
     audit_store: A,
     run_correlations: BTreeMap<RunId, CorrelationId>,
+    campaign_correlations: BTreeMap<CampaignId, CorrelationId>,
+    next_campaign_sequence: BTreeMap<CampaignId, u64>,
 }
 
 impl<S: SnapshotStore, A: AuditLogStore> ObservableExecutionOrchestrator<S, A> {
     pub fn new(store: S, mut audit_store: A) -> Result<Self, OrchestratorError> {
         let inner = ExecutionOrchestrator::new(store)?;
         let mut run_correlations = BTreeMap::new();
+        let mut campaign_correlations = BTreeMap::new();
+        let mut next_campaign_sequence = BTreeMap::new();
         for event in audit_store.load_events()? {
             if let Some(run_id) = event_run_id(&event.payload) {
                 run_correlations
                     .entry(run_id)
                     .or_insert(event.correlation_id);
+            }
+            if let Some((campaign_id, sequence)) = event_campaign_meta(&event.payload) {
+                campaign_correlations
+                    .entry(campaign_id.clone())
+                    .or_insert(event.correlation_id);
+                let candidate_next = sequence.saturating_add(1);
+                let entry = next_campaign_sequence.entry(campaign_id).or_insert(1);
+                if *entry < candidate_next {
+                    *entry = candidate_next;
+                }
             }
         }
         for run_id in inner.runs.keys() {
@@ -1274,6 +1293,8 @@ impl<S: SnapshotStore, A: AuditLogStore> ObservableExecutionOrchestrator<S, A> {
             inner,
             audit_store,
             run_correlations,
+            campaign_correlations,
+            next_campaign_sequence,
         })
     }
 
@@ -1551,12 +1572,96 @@ impl<S: SnapshotStore, A: AuditLogStore> ObservableExecutionOrchestrator<S, A> {
         Ok(effective)
     }
 
+    pub fn record_campaign_event(
+        &mut self,
+        payload: CampaignPayload,
+        correlation_id: Option<CorrelationId>,
+    ) -> Result<(CorrelationId, u64), OrchestratorError> {
+        let campaign_id = payload.campaign_id().clone();
+        let effective = match (
+            self.campaign_correlations.get(&campaign_id).copied(),
+            correlation_id,
+        ) {
+            (Some(existing), Some(provided)) if existing != provided => {
+                return Err(OrchestratorError::Validation(format!(
+                    "campaign {} already bound to lineage {} but {} was provided",
+                    campaign_id.as_str(),
+                    existing.0 .0,
+                    provided.0 .0
+                )));
+            }
+            (Some(existing), _) => existing,
+            (None, Some(provided)) => {
+                self.campaign_correlations
+                    .insert(campaign_id.clone(), provided);
+                provided
+            }
+            (None, None) => {
+                let generated = CorrelationId::next();
+                self.campaign_correlations
+                    .insert(campaign_id.clone(), generated);
+                generated
+            }
+        };
+
+        let sequence = *self
+            .next_campaign_sequence
+            .entry(campaign_id.clone())
+            .or_insert(1);
+        let occurred_at = now_secs();
+        let event = CampaignAuditEvent {
+            sequence,
+            occurred_at,
+            payload,
+        };
+        self.append_event(effective, AuditEventPayload::Campaign(event))?;
+        self.next_campaign_sequence
+            .insert(campaign_id, sequence.saturating_add(1));
+        Ok((effective, sequence))
+    }
+
+    pub fn record_campaign_events<I>(
+        &mut self,
+        payloads: I,
+        correlation_id: Option<CorrelationId>,
+    ) -> Result<CorrelationId, OrchestratorError>
+    where
+        I: IntoIterator<Item = CampaignPayload>,
+    {
+        let payloads = payloads.into_iter().collect::<Vec<_>>();
+        if payloads.is_empty() {
+            return Err(OrchestratorError::Validation(
+                "campaign payload batch cannot be empty".to_string(),
+            ));
+        }
+
+        let campaign_id = payloads[0].campaign_id().clone();
+        for payload in payloads.iter().skip(1) {
+            if payload.campaign_id() != &campaign_id {
+                return Err(OrchestratorError::Validation(
+                    "all campaign payloads in a batch must belong to one campaign".to_string(),
+                ));
+            }
+        }
+
+        let mut effective = correlation_id;
+        for payload in payloads {
+            let (lineage, _sequence) = self.record_campaign_event(payload, effective)?;
+            effective = Some(lineage);
+        }
+        Ok(effective.expect("non-empty payload batch must produce lineage"))
+    }
+
     pub fn load_audit_events(&mut self) -> Result<Vec<AuditEvent>, OrchestratorError> {
         self.audit_store.load_events()
     }
 
     pub fn correlation_id_for_run(&self, run_id: RunId) -> Option<CorrelationId> {
         self.run_correlations.get(&run_id).copied()
+    }
+
+    pub fn correlation_id_for_campaign(&self, campaign_id: &CampaignId) -> Option<CorrelationId> {
+        self.campaign_correlations.get(campaign_id).copied()
     }
 
     pub fn reconstruct_run_from_history(
@@ -2060,6 +2165,99 @@ fn encode_audit_event(event: &AuditEvent) -> String {
             parts.push(encode_hex(module_path));
             parts.push(run_id.0 .0.to_string());
         }
+        AuditEventPayload::Campaign(event) => match &event.payload {
+            CampaignPayload::CampaignCreated { campaign_id, name } => {
+                parts.push("campaign_created".to_string());
+                parts.push(event.sequence.to_string());
+                parts.push(campaign_id.as_str().to_string());
+                parts.push(encode_hex(name));
+            }
+            CampaignPayload::CampaignStatusChanged {
+                campaign_id,
+                from,
+                to,
+                reason,
+            } => {
+                parts.push("campaign_status_changed".to_string());
+                parts.push(event.sequence.to_string());
+                parts.push(campaign_id.as_str().to_string());
+                parts.push(from.as_str().to_string());
+                parts.push(to.as_str().to_string());
+                parts.push(encode_opt_string(reason.as_deref()));
+            }
+            CampaignPayload::ObjectiveCreated {
+                campaign_id,
+                objective_id,
+                name,
+                risk_level,
+            } => {
+                parts.push("objective_created".to_string());
+                parts.push(event.sequence.to_string());
+                parts.push(campaign_id.as_str().to_string());
+                parts.push(objective_id.as_str().to_string());
+                parts.push(encode_hex(name));
+                parts.push(risk_level.as_str().to_string());
+            }
+            CampaignPayload::ObjectivePrereqLinked {
+                campaign_id,
+                objective_id,
+                prerequisite_id,
+            } => {
+                parts.push("objective_prereq_linked".to_string());
+                parts.push(event.sequence.to_string());
+                parts.push(campaign_id.as_str().to_string());
+                parts.push(objective_id.as_str().to_string());
+                parts.push(prerequisite_id.as_str().to_string());
+            }
+            CampaignPayload::ObjectiveStatusChanged {
+                campaign_id,
+                objective_id,
+                from,
+                to,
+                reason,
+            } => {
+                parts.push("objective_status_changed".to_string());
+                parts.push(event.sequence.to_string());
+                parts.push(campaign_id.as_str().to_string());
+                parts.push(objective_id.as_str().to_string());
+                parts.push(from.as_str().to_string());
+                parts.push(to.as_str().to_string());
+                parts.push(encode_opt_string(reason.as_deref()));
+            }
+            CampaignPayload::ObjectiveEvaluated {
+                campaign_id,
+                objective_id,
+                trigger,
+                prerequisites_satisfied,
+                success_criteria_satisfied,
+                failure_criteria_satisfied,
+                resulting_status,
+            } => {
+                parts.push("objective_evaluated".to_string());
+                parts.push(event.sequence.to_string());
+                parts.push(campaign_id.as_str().to_string());
+                parts.push(objective_id.as_str().to_string());
+                parts.push(trigger.as_str().to_string());
+                parts.push(if *prerequisites_satisfied { "1" } else { "0" }.to_string());
+                parts.push(
+                    if *success_criteria_satisfied {
+                        "1"
+                    } else {
+                        "0"
+                    }
+                    .to_string(),
+                );
+                parts.push(
+                    if *failure_criteria_satisfied {
+                        "1"
+                    } else {
+                        "0"
+                    }
+                    .to_string(),
+                );
+                parts.push(resulting_status.as_str().to_string());
+            }
+        },
     }
     parts.join("|")
 }
@@ -2332,6 +2530,115 @@ fn decode_audit_event(line: &str) -> Result<AuditEvent, OrchestratorError> {
                 run_id: RunId(Id(parse_u64(parts[6])?)),
             })
         }
+        "campaign_created" => {
+            if parts.len() != 8 {
+                return Err(OrchestratorError::Parse(format!(
+                    "invalid campaign_created event '{}'",
+                    line
+                )));
+            }
+            AuditEventPayload::Campaign(CampaignAuditEvent {
+                sequence: parse_u64(parts[5])?,
+                occurred_at,
+                payload: CampaignPayload::CampaignCreated {
+                    campaign_id: parse_campaign_id(parts[6])?,
+                    name: decode_hex(parts[7])?,
+                },
+            })
+        }
+        "campaign_status_changed" => {
+            if parts.len() != 10 {
+                return Err(OrchestratorError::Parse(format!(
+                    "invalid campaign_status_changed event '{}'",
+                    line
+                )));
+            }
+            AuditEventPayload::Campaign(CampaignAuditEvent {
+                sequence: parse_u64(parts[5])?,
+                occurred_at,
+                payload: CampaignPayload::CampaignStatusChanged {
+                    campaign_id: parse_campaign_id(parts[6])?,
+                    from: parse_campaign_status(parts[7])?,
+                    to: parse_campaign_status(parts[8])?,
+                    reason: decode_opt_string(parts[9])?,
+                },
+            })
+        }
+        "objective_created" => {
+            if parts.len() != 10 {
+                return Err(OrchestratorError::Parse(format!(
+                    "invalid objective_created event '{}'",
+                    line
+                )));
+            }
+            AuditEventPayload::Campaign(CampaignAuditEvent {
+                sequence: parse_u64(parts[5])?,
+                occurred_at,
+                payload: CampaignPayload::ObjectiveCreated {
+                    campaign_id: parse_campaign_id(parts[6])?,
+                    objective_id: parse_objective_id(parts[7])?,
+                    name: decode_hex(parts[8])?,
+                    risk_level: parse_risk_level(parts[9])?,
+                },
+            })
+        }
+        "objective_prereq_linked" => {
+            if parts.len() != 9 {
+                return Err(OrchestratorError::Parse(format!(
+                    "invalid objective_prereq_linked event '{}'",
+                    line
+                )));
+            }
+            AuditEventPayload::Campaign(CampaignAuditEvent {
+                sequence: parse_u64(parts[5])?,
+                occurred_at,
+                payload: CampaignPayload::ObjectivePrereqLinked {
+                    campaign_id: parse_campaign_id(parts[6])?,
+                    objective_id: parse_objective_id(parts[7])?,
+                    prerequisite_id: parse_objective_id(parts[8])?,
+                },
+            })
+        }
+        "objective_status_changed" => {
+            if parts.len() != 11 {
+                return Err(OrchestratorError::Parse(format!(
+                    "invalid objective_status_changed event '{}'",
+                    line
+                )));
+            }
+            AuditEventPayload::Campaign(CampaignAuditEvent {
+                sequence: parse_u64(parts[5])?,
+                occurred_at,
+                payload: CampaignPayload::ObjectiveStatusChanged {
+                    campaign_id: parse_campaign_id(parts[6])?,
+                    objective_id: parse_objective_id(parts[7])?,
+                    from: parse_objective_status(parts[8])?,
+                    to: parse_objective_status(parts[9])?,
+                    reason: decode_opt_string(parts[10])?,
+                },
+            })
+        }
+        "objective_evaluated" => {
+            if parts.len() != 13 {
+                return Err(OrchestratorError::Parse(format!(
+                    "invalid objective_evaluated event '{}'",
+                    line
+                )));
+            }
+            AuditEventPayload::Campaign(CampaignAuditEvent {
+                sequence: parse_u64(parts[5])?,
+                occurred_at,
+                payload: CampaignPayload::ObjectiveEvaluated {
+                    campaign_id: parse_campaign_id(parts[6])?,
+                    objective_id: parse_objective_id(parts[7])?,
+                    trigger: parse_objective_trigger(parts[8])?,
+                    prerequisites_satisfied: parse_bool_01(parts[9])?,
+                    success_criteria_satisfied: parse_bool_01(parts[10])?,
+                    failure_criteria_satisfied: parse_bool_01(parts[11])?,
+                    resulting_status: parse_objective_status(parts[12])?,
+                },
+            })
+        }
         _ => {
             return Err(OrchestratorError::Parse(format!(
                 "unknown audit event kind '{}'",
@@ -2363,6 +2670,15 @@ fn event_run_id(payload: &AuditEventPayload) -> Option<RunId> {
             ..
         }) => Some(*run_id),
         AuditEventPayload::Module(ModuleEvent::Executed { run_id, .. }) => Some(*run_id),
+        _ => None,
+    }
+}
+
+fn event_campaign_meta(payload: &AuditEventPayload) -> Option<(CampaignId, u64)> {
+    match payload {
+        AuditEventPayload::Campaign(event) => {
+            Some((event.payload.campaign_id().clone(), event.sequence))
+        }
         _ => None,
     }
 }
@@ -2678,6 +2994,83 @@ fn parse_task_state(state: &str) -> Result<TaskState, OrchestratorError> {
         _ => Err(OrchestratorError::Parse(format!(
             "invalid task state '{}'",
             state
+        ))),
+    }
+}
+
+fn parse_bool_01(input: &str) -> Result<bool, OrchestratorError> {
+    match input {
+        "0" => Ok(false),
+        "1" => Ok(true),
+        _ => Err(OrchestratorError::Parse(format!(
+            "invalid boolean flag '{}' (expected 0 or 1)",
+            input
+        ))),
+    }
+}
+
+fn parse_campaign_id(input: &str) -> Result<CampaignId, OrchestratorError> {
+    CampaignId::parse(input).map_err(|err| {
+        OrchestratorError::Parse(format!("invalid campaign id '{}': {}", input, err))
+    })
+}
+
+fn parse_objective_id(input: &str) -> Result<ObjectiveId, OrchestratorError> {
+    ObjectiveId::parse(input).map_err(|err| {
+        OrchestratorError::Parse(format!("invalid objective id '{}': {}", input, err))
+    })
+}
+
+fn parse_campaign_status(input: &str) -> Result<CampaignStatus, OrchestratorError> {
+    match input {
+        "active" => Ok(CampaignStatus::Active),
+        "paused" => Ok(CampaignStatus::Paused),
+        "completed" => Ok(CampaignStatus::Completed),
+        "failed" => Ok(CampaignStatus::Failed),
+        _ => Err(OrchestratorError::Parse(format!(
+            "invalid campaign status '{}'",
+            input
+        ))),
+    }
+}
+
+fn parse_objective_status(input: &str) -> Result<ObjectiveStatus, OrchestratorError> {
+    match input {
+        "pending" => Ok(ObjectiveStatus::Pending),
+        "eligible" => Ok(ObjectiveStatus::Eligible),
+        "in_progress" => Ok(ObjectiveStatus::InProgress),
+        "achieved" => Ok(ObjectiveStatus::Achieved),
+        "failed" => Ok(ObjectiveStatus::Failed),
+        _ => Err(OrchestratorError::Parse(format!(
+            "invalid objective status '{}'",
+            input
+        ))),
+    }
+}
+
+fn parse_risk_level(input: &str) -> Result<RiskLevel, OrchestratorError> {
+    match input {
+        "low" => Ok(RiskLevel::Low),
+        "medium" => Ok(RiskLevel::Medium),
+        "high" => Ok(RiskLevel::High),
+        _ => Err(OrchestratorError::Parse(format!(
+            "invalid risk level '{}'",
+            input
+        ))),
+    }
+}
+
+fn parse_objective_trigger(input: &str) -> Result<ObjectiveReevaluationTrigger, OrchestratorError> {
+    match input {
+        "artifact_created" => Ok(ObjectiveReevaluationTrigger::ArtifactCreated),
+        "finding_created" => Ok(ObjectiveReevaluationTrigger::FindingCreated),
+        "session_state_changed" => Ok(ObjectiveReevaluationTrigger::SessionStateChanged),
+        "run_completed" => Ok(ObjectiveReevaluationTrigger::RunCompleted),
+        "replay_recovery" => Ok(ObjectiveReevaluationTrigger::ReplayRecovery),
+        "manual_request" => Ok(ObjectiveReevaluationTrigger::ManualRequest),
+        _ => Err(OrchestratorError::Parse(format!(
+            "invalid objective trigger '{}'",
+            input
         ))),
     }
 }
@@ -3405,5 +3798,154 @@ mod tests {
             )
             .expect("module event");
         assert_eq!(module_corr, run_correlation);
+    }
+
+    #[test]
+    fn campaign_events_use_single_lineage_and_gapless_sequence() {
+        let snapshot_shared = Arc::new(Mutex::new(None));
+        let audit_shared = Arc::new(Mutex::new(Vec::<AuditEvent>::new()));
+        let campaign_id =
+            CampaignId::parse("de305d54-75b4-431b-adb2-eb6b9e546014").expect("campaign id");
+        let objective_a =
+            ObjectiveId::parse("0f8fad5b-d9cb-469f-a165-70867728950e").expect("objective a");
+        let objective_b =
+            ObjectiveId::parse("9b2f4d6a-3aa4-41ba-91ed-6308a58186a1").expect("objective b");
+
+        let first_lineage = {
+            let snapshot_store = InMemorySnapshotStore::from_shared(Arc::clone(&snapshot_shared));
+            let audit_store = InMemoryAuditLogStore::from_shared(Arc::clone(&audit_shared));
+            let mut orchestrator =
+                ObservableExecutionOrchestrator::new(snapshot_store, audit_store).expect("new");
+
+            let (lineage, seq1) = orchestrator
+                .record_campaign_event(
+                    CampaignPayload::CampaignCreated {
+                        campaign_id: campaign_id.clone(),
+                        name: "operation".to_string(),
+                    },
+                    None,
+                )
+                .expect("campaign create");
+            assert_eq!(seq1, 1);
+
+            let (lineage2, seq2) = orchestrator
+                .record_campaign_event(
+                    CampaignPayload::ObjectiveCreated {
+                        campaign_id: campaign_id.clone(),
+                        objective_id: objective_a.clone(),
+                        name: "initial access".to_string(),
+                        risk_level: RiskLevel::Medium,
+                    },
+                    None,
+                )
+                .expect("objective create");
+            assert_eq!(lineage2, lineage);
+            assert_eq!(seq2, 2);
+
+            let (lineage3, seq3) = orchestrator
+                .record_campaign_event(
+                    CampaignPayload::ObjectivePrereqLinked {
+                        campaign_id: campaign_id.clone(),
+                        objective_id: objective_b.clone(),
+                        prerequisite_id: objective_a.clone(),
+                    },
+                    None,
+                )
+                .expect("prereq link");
+            assert_eq!(lineage3, lineage);
+            assert_eq!(seq3, 3);
+
+            let explicit_mismatch = CorrelationId::next();
+            let err = orchestrator
+                .record_campaign_event(
+                    CampaignPayload::CampaignStatusChanged {
+                        campaign_id: campaign_id.clone(),
+                        from: CampaignStatus::Active,
+                        to: CampaignStatus::Paused,
+                        reason: None,
+                    },
+                    Some(explicit_mismatch),
+                )
+                .expect_err("lineage mismatch must fail");
+            assert!(
+                err.to_string().contains("already bound to lineage"),
+                "unexpected error: {err}"
+            );
+
+            lineage
+        };
+
+        let snapshot_store = InMemorySnapshotStore::from_shared(Arc::clone(&snapshot_shared));
+        let audit_store = InMemoryAuditLogStore::from_shared(Arc::clone(&audit_shared));
+        let mut recovered =
+            ObservableExecutionOrchestrator::new(snapshot_store, audit_store).expect("recover");
+        let (lineage_after_restart, seq4) = recovered
+            .record_campaign_event(
+                CampaignPayload::ObjectiveStatusChanged {
+                    campaign_id: campaign_id.clone(),
+                    objective_id: objective_a,
+                    from: ObjectiveStatus::Eligible,
+                    to: ObjectiveStatus::InProgress,
+                    reason: Some("operator start".to_string()),
+                },
+                None,
+            )
+            .expect("status change");
+        assert_eq!(lineage_after_restart, first_lineage);
+        assert_eq!(seq4, 4);
+
+        let events = recovered.load_audit_events().expect("events");
+        let campaign_events = events
+            .iter()
+            .filter_map(|event| match &event.payload {
+                AuditEventPayload::Campaign(campaign_event) => {
+                    Some((event.correlation_id, campaign_event.sequence))
+                }
+                _ => None,
+            })
+            .collect::<Vec<_>>();
+        assert_eq!(campaign_events.len(), 4);
+        for (idx, (correlation, sequence)) in campaign_events.iter().enumerate() {
+            assert_eq!(*correlation, first_lineage);
+            assert_eq!(*sequence, (idx as u64) + 1);
+        }
+    }
+
+    #[test]
+    fn campaign_events_round_trip_in_file_audit_log() {
+        let path =
+            std::env::temp_dir().join(format!("moonlight-campaign-audit-{}.log", Id::next().0));
+        let mut store = FileAuditLogStore::new(&path);
+        let campaign_id =
+            CampaignId::parse("de305d54-75b4-431b-adb2-eb6b9e546014").expect("campaign id");
+        let objective_id =
+            ObjectiveId::parse("0f8fad5b-d9cb-469f-a165-70867728950e").expect("objective");
+
+        let event = AuditEvent {
+            id: EventId::next(),
+            correlation_id: CorrelationId::next(),
+            occurred_at: now_secs(),
+            payload: AuditEventPayload::Campaign(CampaignAuditEvent {
+                sequence: 7,
+                occurred_at: now_secs(),
+                payload: CampaignPayload::ObjectiveEvaluated {
+                    campaign_id,
+                    objective_id,
+                    trigger: ObjectiveReevaluationTrigger::RunCompleted,
+                    prerequisites_satisfied: true,
+                    success_criteria_satisfied: true,
+                    failure_criteria_satisfied: false,
+                    resulting_status: ObjectiveStatus::Achieved,
+                },
+            }),
+        };
+
+        store.append_event(&event).expect("append");
+        let loaded = store.load_events().expect("load");
+        assert_eq!(loaded.len(), 1);
+        assert_eq!(loaded[0].payload, event.payload);
+        assert_eq!(loaded[0].correlation_id, event.correlation_id);
+
+        let _ = std::fs::remove_file(path);
     }
 }

--- a/core/core/src/orchestrator.rs
+++ b/core/core/src/orchestrator.rs
@@ -6,11 +6,13 @@ use std::sync::{Arc, Mutex};
 
 use crate::campaign::{
     CampaignEvent as CampaignAuditEvent, CampaignEventPayload as CampaignPayload, CampaignId,
-    CampaignStatus, ObjectiveId, ObjectiveReevaluationTrigger, ObjectiveStatus, RiskLevel,
+    CampaignStatus, Objective, ObjectiveId, ObjectiveIngestionDispatch,
+    ObjectiveIngestionDispatcher, ObjectiveIngestionEvent, ObjectiveReevaluationTrigger,
+    ObjectiveStatus, PredicateSnapshot, RiskLevel,
 };
 use crate::domain::{
-    CorrelationId, DomainError, EventId, ModuleVersionId, Run, RunId, RunState, SessionId,
-    TargetId, Task, TaskId, TaskState, WorkspaceId,
+    ArtifactId, CorrelationId, DomainError, EventId, FindingId, ModuleVersionId, Run, RunId,
+    RunState, SessionId, TargetId, Task, TaskId, TaskState, WorkspaceId,
 };
 use crate::ids::Id;
 use crate::time::now_secs;
@@ -1259,6 +1261,7 @@ pub struct ObservableExecutionOrchestrator<S: SnapshotStore, A: AuditLogStore> {
     run_correlations: BTreeMap<RunId, CorrelationId>,
     campaign_correlations: BTreeMap<CampaignId, CorrelationId>,
     next_campaign_sequence: BTreeMap<CampaignId, u64>,
+    campaign_ingestion_dispatchers: BTreeMap<CampaignId, ObjectiveIngestionDispatcher>,
 }
 
 impl<S: SnapshotStore, A: AuditLogStore> ObservableExecutionOrchestrator<S, A> {
@@ -1295,6 +1298,7 @@ impl<S: SnapshotStore, A: AuditLogStore> ObservableExecutionOrchestrator<S, A> {
             run_correlations,
             campaign_correlations,
             next_campaign_sequence,
+            campaign_ingestion_dispatchers: BTreeMap::new(),
         })
     }
 
@@ -1652,6 +1656,77 @@ impl<S: SnapshotStore, A: AuditLogStore> ObservableExecutionOrchestrator<S, A> {
         Ok(effective.expect("non-empty payload batch must produce lineage"))
     }
 
+    pub fn ingest_artifact_created(
+        &mut self,
+        campaign_id: CampaignId,
+        objectives: &mut BTreeMap<ObjectiveId, Objective>,
+        snapshot: &PredicateSnapshot,
+        artifact_id: ArtifactId,
+        correlation_id: Option<CorrelationId>,
+    ) -> Result<ObjectiveIngestionDispatch, OrchestratorError> {
+        let event = ObjectiveIngestionEvent::new(
+            campaign_id,
+            ObjectiveReevaluationTrigger::ArtifactCreated,
+            &format!("artifact_created:{}", artifact_id.0 .0),
+        )
+        .map_err(|err| OrchestratorError::Validation(err.to_string()))?;
+        self.ingest_campaign_trigger(event, objectives, snapshot, correlation_id)
+    }
+
+    pub fn ingest_finding_created(
+        &mut self,
+        campaign_id: CampaignId,
+        objectives: &mut BTreeMap<ObjectiveId, Objective>,
+        snapshot: &PredicateSnapshot,
+        finding_id: FindingId,
+        correlation_id: Option<CorrelationId>,
+    ) -> Result<ObjectiveIngestionDispatch, OrchestratorError> {
+        let event = ObjectiveIngestionEvent::new(
+            campaign_id,
+            ObjectiveReevaluationTrigger::FindingCreated,
+            &format!("finding_created:{}", finding_id.0 .0),
+        )
+        .map_err(|err| OrchestratorError::Validation(err.to_string()))?;
+        self.ingest_campaign_trigger(event, objectives, snapshot, correlation_id)
+    }
+
+    pub fn ingest_session_state_changed(
+        &mut self,
+        campaign_id: CampaignId,
+        objectives: &mut BTreeMap<ObjectiveId, Objective>,
+        snapshot: &PredicateSnapshot,
+        session_id: SessionId,
+        run_id: Option<RunId>,
+        correlation_id: Option<CorrelationId>,
+    ) -> Result<ObjectiveIngestionDispatch, OrchestratorError> {
+        let propagated = correlation_id.or(run_id.and_then(|id| self.correlation_id_for_run(id)));
+        let event = ObjectiveIngestionEvent::new(
+            campaign_id,
+            ObjectiveReevaluationTrigger::SessionStateChanged,
+            &format!("session_state_changed:{}", session_id.0 .0),
+        )
+        .map_err(|err| OrchestratorError::Validation(err.to_string()))?;
+        self.ingest_campaign_trigger(event, objectives, snapshot, propagated)
+    }
+
+    pub fn ingest_run_completed(
+        &mut self,
+        campaign_id: CampaignId,
+        objectives: &mut BTreeMap<ObjectiveId, Objective>,
+        snapshot: &PredicateSnapshot,
+        run_id: RunId,
+        correlation_id: Option<CorrelationId>,
+    ) -> Result<ObjectiveIngestionDispatch, OrchestratorError> {
+        let propagated = correlation_id.or(self.correlation_id_for_run(run_id));
+        let event = ObjectiveIngestionEvent::new(
+            campaign_id,
+            ObjectiveReevaluationTrigger::RunCompleted,
+            &format!("run_completed:{}", run_id.0 .0),
+        )
+        .map_err(|err| OrchestratorError::Validation(err.to_string()))?;
+        self.ingest_campaign_trigger(event, objectives, snapshot, propagated)
+    }
+
     pub fn load_audit_events(&mut self) -> Result<Vec<AuditEvent>, OrchestratorError> {
         self.audit_store.load_events()
     }
@@ -1662,6 +1737,38 @@ impl<S: SnapshotStore, A: AuditLogStore> ObservableExecutionOrchestrator<S, A> {
 
     pub fn correlation_id_for_campaign(&self, campaign_id: &CampaignId) -> Option<CorrelationId> {
         self.campaign_correlations.get(campaign_id).copied()
+    }
+
+    fn ingest_campaign_trigger(
+        &mut self,
+        event: ObjectiveIngestionEvent,
+        objectives: &mut BTreeMap<ObjectiveId, Objective>,
+        snapshot: &PredicateSnapshot,
+        correlation_id: Option<CorrelationId>,
+    ) -> Result<ObjectiveIngestionDispatch, OrchestratorError> {
+        if objectives
+            .values()
+            .any(|objective| objective.campaign_id != event.campaign_id)
+        {
+            return Err(OrchestratorError::Validation(
+                "all objectives must belong to ingestion campaign".to_string(),
+            ));
+        }
+
+        let dispatcher = self
+            .campaign_ingestion_dispatchers
+            .entry(event.campaign_id.clone())
+            .or_default();
+        let dispatch = dispatcher
+            .dispatch(&event, objectives, snapshot, now_secs())
+            .map_err(|err| OrchestratorError::Validation(err.to_string()))?;
+
+        if dispatch.emitted_events.is_empty() {
+            return Ok(dispatch);
+        }
+
+        let _ = self.record_campaign_events(dispatch.emitted_events.clone(), correlation_id)?;
+        Ok(dispatch)
     }
 
     pub fn reconstruct_run_from_history(
@@ -3078,6 +3185,7 @@ fn parse_objective_trigger(input: &str) -> Result<ObjectiveReevaluationTrigger, 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::campaign::Predicate as CampaignPredicate;
     use crate::performance::{PerformanceBudget, PerformanceSample};
     use std::sync::atomic::{AtomicU64, Ordering};
     use std::thread;
@@ -3947,5 +4055,268 @@ mod tests {
         assert_eq!(loaded[0].correlation_id, event.correlation_id);
 
         let _ = std::fs::remove_file(path);
+    }
+
+    #[test]
+    fn ingestion_run_completed_propagates_correlation_and_deduplicates() {
+        let snapshot_store = InMemorySnapshotStore::default();
+        let audit_store = InMemoryAuditLogStore::default();
+        let mut orchestrator =
+            ObservableExecutionOrchestrator::new(snapshot_store, audit_store).expect("new");
+
+        let run_id = orchestrator
+            .submit_run(
+                basic_request(),
+                RunPlan::new(vec![
+                    PlannedTask::new("evt", 1, 100, "ingest-run").expect("task")
+                ])
+                .expect("plan"),
+            )
+            .expect("submit");
+        let run_correlation = orchestrator
+            .correlation_id_for_run(run_id)
+            .expect("run correlation");
+
+        let campaign_id =
+            CampaignId::parse("de305d54-75b4-431b-adb2-eb6b9e546014").expect("campaign id");
+        let objective_id =
+            ObjectiveId::parse("0f8fad5b-d9cb-469f-a165-70867728950e").expect("objective id");
+        let mut objective = Objective::new_at(
+            objective_id.clone(),
+            campaign_id.clone(),
+            "run objective",
+            "run completion should satisfy",
+            vec![],
+            vec![CampaignPredicate::RunSucceeded {
+                module_name: "exploit/linux/example".to_string(),
+            }],
+            vec![],
+            RiskLevel::Medium,
+            None,
+            1,
+        )
+        .expect("objective");
+        objective.status = ObjectiveStatus::InProgress;
+        let mut objectives = BTreeMap::from([(objective_id, objective)]);
+
+        let workspace = crate::domain::Workspace::new_at("ws", "test", 1).expect("workspace");
+        let module = crate::domain::ModuleVersion::new_at(
+            "exploit/linux/example",
+            "1.0.0",
+            1,
+            "entrypoint",
+            "sha256",
+            1,
+        )
+        .expect("module");
+        let mut run =
+            crate::domain::Run::new_at(workspace.id, module.id, None, "operator", 2).expect("run");
+        run.transition_state(RunState::Running, 3).expect("running");
+        run.transition_state(RunState::Succeeded, 4)
+            .expect("succeeded");
+        let snapshot = PredicateSnapshot::new().with_run(
+            crate::campaign::RunSnapshot::new(run, "exploit/linux/example").expect("run snapshot"),
+        );
+
+        let first = orchestrator
+            .ingest_run_completed(
+                campaign_id.clone(),
+                &mut objectives,
+                &snapshot,
+                run_id,
+                None,
+            )
+            .expect("first ingestion");
+        assert!(!first.skipped_duplicate);
+        assert!(!first.emitted_events.is_empty());
+        assert_eq!(
+            orchestrator.correlation_id_for_campaign(&campaign_id),
+            Some(run_correlation)
+        );
+
+        let second = orchestrator
+            .ingest_run_completed(
+                campaign_id.clone(),
+                &mut objectives,
+                &snapshot,
+                run_id,
+                None,
+            )
+            .expect("duplicate ingestion");
+        assert!(second.skipped_duplicate);
+        assert!(second.emitted_events.is_empty());
+
+        let campaign_event_count = orchestrator
+            .load_audit_events()
+            .expect("events")
+            .into_iter()
+            .filter(|event| matches!(event.payload, AuditEventPayload::Campaign(_)))
+            .count();
+        assert_eq!(campaign_event_count, first.emitted_events.len());
+        assert_eq!(
+            objectives.values().next().expect("objective").status,
+            ObjectiveStatus::Achieved
+        );
+    }
+
+    #[test]
+    fn ingestion_artifact_finding_session_triggers_evaluate_relevant_objectives() {
+        let snapshot_store = InMemorySnapshotStore::default();
+        let audit_store = InMemoryAuditLogStore::default();
+        let mut orchestrator =
+            ObservableExecutionOrchestrator::new(snapshot_store, audit_store).expect("new");
+
+        let campaign_id =
+            CampaignId::parse("de305d54-75b4-431b-adb2-eb6b9e546014").expect("campaign id");
+        let objective_artifact =
+            ObjectiveId::parse("0f8fad5b-d9cb-469f-a165-70867728950e").expect("objective");
+        let objective_finding =
+            ObjectiveId::parse("9b2f4d6a-3aa4-41ba-91ed-6308a58186a1").expect("objective");
+        let objective_session =
+            ObjectiveId::parse("f47ac10b-58cc-4372-a567-0e02b2c3d479").expect("objective");
+
+        let mut obj_a = Objective::new_at(
+            objective_artifact.clone(),
+            campaign_id.clone(),
+            "artifact objective",
+            "artifact trigger",
+            vec![],
+            vec![CampaignPredicate::ArtifactTagMatch {
+                tag: "loot".to_string(),
+            }],
+            vec![],
+            RiskLevel::Low,
+            None,
+            1,
+        )
+        .expect("objective");
+        obj_a.status = ObjectiveStatus::InProgress;
+
+        let mut obj_b = Objective::new_at(
+            objective_finding.clone(),
+            campaign_id.clone(),
+            "finding objective",
+            "finding trigger",
+            vec![],
+            vec![CampaignPredicate::FindingExists {
+                finding_type: "credential".to_string(),
+            }],
+            vec![],
+            RiskLevel::Low,
+            None,
+            1,
+        )
+        .expect("objective");
+        obj_b.status = ObjectiveStatus::InProgress;
+
+        let mut obj_c = Objective::new_at(
+            objective_session.clone(),
+            campaign_id.clone(),
+            "session objective",
+            "session trigger",
+            vec![],
+            vec![CampaignPredicate::SessionPrivilege {
+                level: crate::campaign::SessionPrivilegeLevel::Root,
+            }],
+            vec![],
+            RiskLevel::Low,
+            None,
+            1,
+        )
+        .expect("objective");
+        obj_c.status = ObjectiveStatus::InProgress;
+
+        let mut objectives = BTreeMap::from([
+            (objective_artifact.clone(), obj_a),
+            (objective_finding.clone(), obj_b),
+            (objective_session.clone(), obj_c),
+        ]);
+
+        let workspace = crate::domain::Workspace::new_at("ws", "test", 1).expect("workspace");
+        let module = crate::domain::ModuleVersion::new_at(
+            "exploit/linux/example",
+            "1.0.0",
+            1,
+            "entrypoint",
+            "sha256",
+            1,
+        )
+        .expect("module");
+        let run =
+            crate::domain::Run::new_at(workspace.id, module.id, None, "operator", 2).expect("run");
+        let session = crate::domain::Session::new_at(run.id, None, "shell", "127.0.0.1:23", 3)
+            .expect("session");
+        let artifact = crate::domain::Artifact::new_at(
+            run.id,
+            None,
+            Some(session.id),
+            crate::domain::ArtifactKind::CommandOutput,
+            "loot",
+            "memory://loot",
+            4,
+        )
+        .expect("artifact");
+        let finding = crate::domain::Finding::new_at(
+            run.id,
+            None,
+            Some(session.id),
+            "Credential",
+            "found secret",
+            crate::domain::FindingSeverity::High,
+            5,
+        )
+        .expect("finding");
+
+        let snapshot = PredicateSnapshot::new()
+            .with_artifact(crate::campaign::ArtifactSnapshot::new(artifact).with_tag("loot"))
+            .with_finding(
+                crate::campaign::FindingSnapshot::new(finding, "credential").expect("snapshot"),
+            )
+            .with_session(
+                crate::campaign::SessionSnapshot::new(session)
+                    .with_privilege(crate::campaign::SessionPrivilegeLevel::Root),
+            );
+
+        orchestrator
+            .ingest_artifact_created(
+                campaign_id.clone(),
+                &mut objectives,
+                &snapshot,
+                ArtifactId::next(),
+                None,
+            )
+            .expect("artifact trigger");
+        orchestrator
+            .ingest_finding_created(
+                campaign_id.clone(),
+                &mut objectives,
+                &snapshot,
+                FindingId::next(),
+                None,
+            )
+            .expect("finding trigger");
+        orchestrator
+            .ingest_session_state_changed(
+                campaign_id.clone(),
+                &mut objectives,
+                &snapshot,
+                SessionId::next(),
+                None,
+                None,
+            )
+            .expect("session trigger");
+
+        assert_eq!(
+            objectives[&objective_artifact].status,
+            ObjectiveStatus::Achieved
+        );
+        assert_eq!(
+            objectives[&objective_finding].status,
+            ObjectiveStatus::Achieved
+        );
+        assert_eq!(
+            objectives[&objective_session].status,
+            ObjectiveStatus::Achieved
+        );
     }
 }

--- a/core/core/src/policy.rs
+++ b/core/core/src/policy.rs
@@ -59,6 +59,12 @@ pub enum PolicyAction {
     ExecuteModule,
     CloseSession,
     CloseAllSessions,
+    CreateCampaign,
+    ChangeCampaignStatus,
+    CreateObjective,
+    LinkObjectivePrerequisite,
+    StartObjective,
+    EvaluateObjective,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -95,6 +101,12 @@ pub struct PolicyRequest {
     pub action: PolicyAction,
     pub module: Option<ModuleContext>,
     pub target: Option<String>,
+    pub campaign_id: Option<String>,
+    pub objective_id: Option<String>,
+    pub prerequisite_id: Option<String>,
+    pub risk_level: Option<String>,
+    pub from_status: Option<String>,
+    pub to_status: Option<String>,
 }
 
 impl PolicyRequest {
@@ -103,6 +115,12 @@ impl PolicyRequest {
             action: PolicyAction::ExecuteModule,
             module: Some(module),
             target,
+            campaign_id: None,
+            objective_id: None,
+            prerequisite_id: None,
+            risk_level: None,
+            from_status: None,
+            to_status: None,
         }
     }
 
@@ -111,6 +129,12 @@ impl PolicyRequest {
             action: PolicyAction::CloseSession,
             module: None,
             target: None,
+            campaign_id: None,
+            objective_id: None,
+            prerequisite_id: None,
+            risk_level: None,
+            from_status: None,
+            to_status: None,
         }
     }
 
@@ -119,6 +143,100 @@ impl PolicyRequest {
             action: PolicyAction::CloseAllSessions,
             module: None,
             target: None,
+            campaign_id: None,
+            objective_id: None,
+            prerequisite_id: None,
+            risk_level: None,
+            from_status: None,
+            to_status: None,
+        }
+    }
+
+    pub fn create_campaign(campaign_id: &str) -> Self {
+        Self {
+            action: PolicyAction::CreateCampaign,
+            module: None,
+            target: None,
+            campaign_id: Some(campaign_id.trim().to_string()),
+            objective_id: None,
+            prerequisite_id: None,
+            risk_level: None,
+            from_status: None,
+            to_status: None,
+        }
+    }
+
+    pub fn change_campaign_status(campaign_id: &str, from_status: &str, to_status: &str) -> Self {
+        Self {
+            action: PolicyAction::ChangeCampaignStatus,
+            module: None,
+            target: None,
+            campaign_id: Some(campaign_id.trim().to_string()),
+            objective_id: None,
+            prerequisite_id: None,
+            risk_level: None,
+            from_status: Some(from_status.trim().to_ascii_lowercase()),
+            to_status: Some(to_status.trim().to_ascii_lowercase()),
+        }
+    }
+
+    pub fn create_objective(campaign_id: &str, objective_id: &str, risk_level: &str) -> Self {
+        Self {
+            action: PolicyAction::CreateObjective,
+            module: None,
+            target: None,
+            campaign_id: Some(campaign_id.trim().to_string()),
+            objective_id: Some(objective_id.trim().to_string()),
+            prerequisite_id: None,
+            risk_level: Some(risk_level.trim().to_ascii_lowercase()),
+            from_status: None,
+            to_status: None,
+        }
+    }
+
+    pub fn link_objective_prerequisite(
+        campaign_id: &str,
+        objective_id: &str,
+        prerequisite_id: &str,
+    ) -> Self {
+        Self {
+            action: PolicyAction::LinkObjectivePrerequisite,
+            module: None,
+            target: None,
+            campaign_id: Some(campaign_id.trim().to_string()),
+            objective_id: Some(objective_id.trim().to_string()),
+            prerequisite_id: Some(prerequisite_id.trim().to_string()),
+            risk_level: None,
+            from_status: None,
+            to_status: None,
+        }
+    }
+
+    pub fn start_objective(campaign_id: &str, objective_id: &str, risk_level: &str) -> Self {
+        Self {
+            action: PolicyAction::StartObjective,
+            module: None,
+            target: None,
+            campaign_id: Some(campaign_id.trim().to_string()),
+            objective_id: Some(objective_id.trim().to_string()),
+            prerequisite_id: None,
+            risk_level: Some(risk_level.trim().to_ascii_lowercase()),
+            from_status: None,
+            to_status: None,
+        }
+    }
+
+    pub fn evaluate_objective(campaign_id: &str, objective_id: &str, risk_level: &str) -> Self {
+        Self {
+            action: PolicyAction::EvaluateObjective,
+            module: None,
+            target: None,
+            campaign_id: Some(campaign_id.trim().to_string()),
+            objective_id: Some(objective_id.trim().to_string()),
+            prerequisite_id: None,
+            risk_level: Some(risk_level.trim().to_ascii_lowercase()),
+            from_status: None,
+            to_status: None,
         }
     }
 }
@@ -197,7 +315,82 @@ impl DefaultSafetyPolicy {
                 )
             }
             PolicyAction::ExecuteModule => self.evaluate_module_execution(request, granted),
+            PolicyAction::CreateCampaign => {
+                PolicyDecision::allow("campaign creation allowed by default safety policy")
+            }
+            PolicyAction::ChangeCampaignStatus => self.evaluate_campaign_status_change(request),
+            PolicyAction::CreateObjective => self.evaluate_objective_create(request, granted),
+            PolicyAction::LinkObjectivePrerequisite => PolicyDecision::allow(
+                "objective prerequisite linkage allowed by default safety policy",
+            ),
+            PolicyAction::StartObjective => self.evaluate_objective_start(request, granted),
+            PolicyAction::EvaluateObjective => {
+                PolicyDecision::allow("objective evaluation allowed by default safety policy")
+            }
         }
+    }
+
+    fn evaluate_campaign_status_change(&self, request: &PolicyRequest) -> PolicyDecision {
+        let Some(to_status) = request.to_status.as_deref() else {
+            return PolicyDecision::deny("campaign status change missing target status");
+        };
+        let campaign_id = request.campaign_id.as_deref().unwrap_or("<unknown>");
+        if matches!(to_status, "completed" | "failed") {
+            return PolicyDecision::confirm(&format!(
+                "Campaign '{}' transition to '{}' requires explicit intent",
+                campaign_id, to_status
+            ));
+        }
+        PolicyDecision::allow("campaign status change allowed by default safety policy")
+    }
+
+    fn evaluate_objective_create(
+        &self,
+        request: &PolicyRequest,
+        granted: &BTreeSet<Capability>,
+    ) -> PolicyDecision {
+        let Some(risk_level) = request.risk_level.as_deref() else {
+            return PolicyDecision::deny("objective creation missing risk level");
+        };
+        let objective_id = request.objective_id.as_deref().unwrap_or("<unknown>");
+        if risk_level == "high" {
+            if !granted.contains(&Capability::ExploitExecution) {
+                return PolicyDecision::deny(
+                    "high-risk objective creation blocked: enable capability exploit_execution",
+                );
+            }
+            return PolicyDecision::confirm(&format!(
+                "Objective '{}' is high risk; confirm explicit intent",
+                objective_id
+            ));
+        }
+        if risk_level == "medium" {
+            return PolicyDecision::confirm(&format!(
+                "Objective '{}' is medium risk; confirm explicit intent",
+                objective_id
+            ));
+        }
+        PolicyDecision::allow("objective creation allowed by default safety policy")
+    }
+
+    fn evaluate_objective_start(
+        &self,
+        request: &PolicyRequest,
+        granted: &BTreeSet<Capability>,
+    ) -> PolicyDecision {
+        let Some(risk_level) = request.risk_level.as_deref() else {
+            return PolicyDecision::deny("objective start missing risk level");
+        };
+        let objective_id = request.objective_id.as_deref().unwrap_or("<unknown>");
+        if risk_level == "high" && !granted.contains(&Capability::ExploitExecution) {
+            return PolicyDecision::deny(
+                "high-risk objective start blocked: enable capability exploit_execution",
+            );
+        }
+        PolicyDecision::confirm(&format!(
+            "Starting objective '{}' (risk={}) requires explicit intent",
+            objective_id, risk_level
+        ))
     }
 
     fn evaluate_module_execution(
@@ -543,5 +736,63 @@ mod tests {
         ));
         assert_eq!(decision.kind, DecisionKind::Deny);
         assert_eq!(decision.reason, "blocked by custom policy hook");
+    }
+
+    #[test]
+    fn campaign_terminal_status_requires_confirmation() {
+        let engine = PolicyEngine::new();
+        let decision = engine.evaluate(&PolicyRequest::change_campaign_status(
+            "de305d54-75b4-431b-adb2-eb6b9e546014",
+            "active",
+            "completed",
+        ));
+        assert_eq!(decision.kind, DecisionKind::RequireConfirmation);
+    }
+
+    #[test]
+    fn high_risk_objective_create_requires_exploit_capability() {
+        let engine = PolicyEngine::new();
+        let denied = engine.evaluate(&PolicyRequest::create_objective(
+            "de305d54-75b4-431b-adb2-eb6b9e546014",
+            "0f8fad5b-d9cb-469f-a165-70867728950e",
+            "high",
+        ));
+        assert_eq!(denied.kind, DecisionKind::Deny);
+
+        let mut engine = PolicyEngine::new();
+        engine.grant(Capability::ExploitExecution);
+        let confirmed = engine.evaluate(&PolicyRequest::create_objective(
+            "de305d54-75b4-431b-adb2-eb6b9e546014",
+            "0f8fad5b-d9cb-469f-a165-70867728950e",
+            "high",
+        ));
+        assert_eq!(confirmed.kind, DecisionKind::RequireConfirmation);
+    }
+
+    #[test]
+    fn objective_start_requires_explicit_intent_and_high_risk_capability() {
+        let engine = PolicyEngine::new();
+        let denied = engine.evaluate(&PolicyRequest::start_objective(
+            "de305d54-75b4-431b-adb2-eb6b9e546014",
+            "0f8fad5b-d9cb-469f-a165-70867728950e",
+            "high",
+        ));
+        assert_eq!(denied.kind, DecisionKind::Deny);
+
+        let medium = engine.evaluate(&PolicyRequest::start_objective(
+            "de305d54-75b4-431b-adb2-eb6b9e546014",
+            "0f8fad5b-d9cb-469f-a165-70867728950e",
+            "medium",
+        ));
+        assert_eq!(medium.kind, DecisionKind::RequireConfirmation);
+
+        let mut engine = PolicyEngine::new();
+        engine.grant(Capability::ExploitExecution);
+        let confirmed = engine.evaluate(&PolicyRequest::start_objective(
+            "de305d54-75b4-431b-adb2-eb6b9e546014",
+            "0f8fad5b-d9cb-469f-a165-70867728950e",
+            "high",
+        ));
+        assert_eq!(confirmed.kind, DecisionKind::RequireConfirmation);
     }
 }

--- a/core/core/src/release.rs
+++ b/core/core/src/release.rs
@@ -93,7 +93,7 @@ impl ReleaseCompatibilityPolicy {
         Self::new(
             VersionWindow::new(1, 1).expect("fixed window"),
             VersionWindow::new(1, 1).expect("fixed window"),
-            VersionWindow::new(1, 3).expect("fixed window"),
+            VersionWindow::new(1, 4).expect("fixed window"),
             vec!["human".to_string(), "json".to_string()],
             vec!["builtin".to_string(), "dynlib".to_string()],
         )
@@ -394,8 +394,17 @@ impl MigrationPolicy {
                 false,
             )
             .expect("valid step"),
+            MigrationStepDefinition::new(
+                3,
+                4,
+                "Persist campaign/objective snapshots with deterministic predicate state.",
+                MigrationImpact::Compatible,
+                true,
+                true,
+            )
+            .expect("valid step"),
         ];
-        Self::new(1, 3, steps).expect("default migration policy")
+        Self::new(1, 4, steps).expect("default migration policy")
     }
 
     pub fn plan(

--- a/core/core/src/release.rs
+++ b/core/core/src/release.rs
@@ -93,7 +93,7 @@ impl ReleaseCompatibilityPolicy {
         Self::new(
             VersionWindow::new(1, 1).expect("fixed window"),
             VersionWindow::new(1, 1).expect("fixed window"),
-            VersionWindow::new(1, 4).expect("fixed window"),
+            VersionWindow::new(1, 5).expect("fixed window"),
             vec!["human".to_string(), "json".to_string()],
             vec!["builtin".to_string(), "dynlib".to_string()],
         )
@@ -403,8 +403,17 @@ impl MigrationPolicy {
                 true,
             )
             .expect("valid step"),
+            MigrationStepDefinition::new(
+                4,
+                5,
+                "Add campaign/objective rollback compatibility envelope in control-state snapshots.",
+                MigrationImpact::Compatible,
+                true,
+                true,
+            )
+            .expect("valid step"),
         ];
-        Self::new(1, 4, steps).expect("default migration policy")
+        Self::new(1, 5, steps).expect("default migration policy")
     }
 
     pub fn plan(
@@ -592,7 +601,94 @@ impl VersionedControlState {
         )
     }
 
-    pub fn apply_rollback_restore(&mut self, restore: &RollbackRestore, restored_at: u64) {
+    pub fn snapshot_payload_with_campaign_objective_state(
+        &self,
+        campaign_count: usize,
+        objective_count: usize,
+    ) -> String {
+        let integrity = if self.schema_version >= 5 {
+            "strict"
+        } else {
+            "legacy"
+        };
+        format!(
+            "schema_version={};history_count={};campaign_count={};objective_count={};campaign_objective_integrity={}",
+            self.schema_version,
+            self.migration_history.len(),
+            campaign_count,
+            objective_count,
+            integrity
+        )
+    }
+
+    pub fn validate_snapshot_payload_compatibility(
+        schema_version: u32,
+        payload: &str,
+    ) -> Result<(), ReleaseError> {
+        let fields = parse_snapshot_payload_fields(payload)?;
+        let encoded_schema = fields
+            .get("schema_version")
+            .ok_or_else(|| {
+                ReleaseError::Validation("snapshot payload missing schema_version".to_string())
+            })?
+            .parse::<u32>()
+            .map_err(|_| {
+                ReleaseError::Parse(
+                    "snapshot payload schema_version must be an integer".to_string(),
+                )
+            })?;
+        if encoded_schema != schema_version {
+            return Err(ReleaseError::Validation(format!(
+                "snapshot schema version mismatch: payload={} restore={}",
+                encoded_schema, schema_version
+            )));
+        }
+
+        if let Some(history) = fields.get("history_count") {
+            history.parse::<usize>().map_err(|_| {
+                ReleaseError::Parse("snapshot payload history_count must be an integer".to_string())
+            })?;
+        }
+
+        if schema_version >= 5 {
+            for key in ["campaign_count", "objective_count"] {
+                let value = fields.get(key).ok_or_else(|| {
+                    ReleaseError::Validation(format!(
+                        "snapshot payload missing '{}' required for schema {}",
+                        key, schema_version
+                    ))
+                })?;
+                value.parse::<usize>().map_err(|_| {
+                    ReleaseError::Parse(format!(
+                        "snapshot payload field '{}' must be an integer",
+                        key
+                    ))
+                })?;
+            }
+            let integrity = fields
+                .get("campaign_objective_integrity")
+                .ok_or_else(|| {
+                    ReleaseError::Validation(
+                        "snapshot payload missing campaign_objective_integrity".to_string(),
+                    )
+                })?
+                .to_ascii_lowercase();
+            if integrity != "strict" {
+                return Err(ReleaseError::Validation(
+                    "snapshot payload campaign_objective_integrity must be strict".to_string(),
+                ));
+            }
+        }
+
+        Ok(())
+    }
+
+    pub fn apply_rollback_restore(
+        &mut self,
+        restore: &RollbackRestore,
+        restored_at: u64,
+    ) -> Result<(), ReleaseError> {
+        Self::validate_snapshot_payload_compatibility(restore.schema_version, &restore.payload)?;
         let previous = self.schema_version;
         self.schema_version = restore.schema_version;
         self.migration_history.push(AppliedMigrationRecord {
@@ -605,6 +701,7 @@ impl VersionedControlState {
                 restore.snapshot_id, restore.label
             ),
         });
+        Ok(())
     }
 }
 
@@ -941,6 +1038,12 @@ impl ReleaseChecklistTemplate {
             )
             .expect("item"),
             ReleaseChecklistItem::new(
+                "rollback_payload_compatibility",
+                "Rollback snapshot payload is compatible with target schema semantics.",
+                true,
+            )
+            .expect("item"),
+            ReleaseChecklistItem::new(
                 "documentation_gates",
                 "Operator usage documentation is complete and current.",
                 true,
@@ -1013,6 +1116,41 @@ fn normalize_unique(values: Vec<String>, field_name: &str) -> Result<Vec<String>
 
 fn normalize_token(value: &str) -> String {
     value.trim().to_ascii_lowercase()
+}
+
+fn parse_snapshot_payload_fields(payload: &str) -> Result<BTreeMap<String, String>, ReleaseError> {
+    let mut fields = BTreeMap::new();
+    for segment in payload.split(';') {
+        let trimmed = segment.trim();
+        if trimmed.is_empty() {
+            continue;
+        }
+        let (raw_key, raw_value) = trimmed.split_once('=').ok_or_else(|| {
+            ReleaseError::Parse(format!(
+                "invalid snapshot payload segment '{}': expected key=value",
+                trimmed
+            ))
+        })?;
+        let key = normalize_token(raw_key);
+        if key.is_empty() {
+            return Err(ReleaseError::Parse(
+                "snapshot payload contains empty key".to_string(),
+            ));
+        }
+        if fields.contains_key(&key) {
+            return Err(ReleaseError::Parse(format!(
+                "snapshot payload contains duplicate key '{}'",
+                key
+            )));
+        }
+        fields.insert(key, raw_value.trim().to_string());
+    }
+    if fields.is_empty() {
+        return Err(ReleaseError::Parse(
+            "snapshot payload cannot be empty".to_string(),
+        ));
+    }
+    Ok(fields)
 }
 
 fn normalize_heading(value: &str) -> String {
@@ -1153,6 +1291,12 @@ mod tests {
         assert_eq!(rollback.steps.len(), 2);
         assert!(rollback.requires_backup);
         assert_eq!(rollback.steps[0].direction, MigrationDirection::Rollback);
+
+        let schema5 = policy.plan(4, 5).expect("schema 5 plan");
+        assert_eq!(schema5.steps.len(), 1);
+        assert_eq!(schema5.steps[0].from_version, 4);
+        assert_eq!(schema5.steps[0].to_version, 5);
+        assert!(schema5.requires_backup);
     }
 
     #[test]
@@ -1200,8 +1344,54 @@ mod tests {
             checksum: checksum_fnv1a("schema_version=1"),
         };
 
-        state.apply_rollback_restore(&restore, 123);
+        state
+            .apply_rollback_restore(&restore, 123)
+            .expect("restore");
         assert_eq!(state.schema_version, 1);
+        assert_eq!(state.migration_history().len(), 1);
+        assert_eq!(
+            state.migration_history()[0].direction,
+            MigrationDirection::Rollback
+        );
+    }
+
+    #[test]
+    fn rollback_restore_requires_campaign_objective_envelope_for_schema_five() {
+        let mut state = VersionedControlState::new(5).expect("state");
+        let incompatible_payload = "schema_version=5;history_count=0";
+        let restore = RollbackRestore {
+            snapshot_id: 11,
+            label: "incompatible-v5".to_string(),
+            schema_version: 5,
+            payload: incompatible_payload.to_string(),
+            checksum: checksum_fnv1a(incompatible_payload),
+        };
+
+        let err = state
+            .apply_rollback_restore(&restore, 200)
+            .expect_err("schema five payload should require campaign/objective envelope");
+        assert!(
+            err.to_string().contains("campaign_count"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn rollback_restore_accepts_schema_five_campaign_objective_envelope() {
+        let mut state = VersionedControlState::new(5).expect("state");
+        let payload = state.snapshot_payload_with_campaign_objective_state(2, 3);
+        let restore = RollbackRestore {
+            snapshot_id: 12,
+            label: "compatible-v5".to_string(),
+            schema_version: 5,
+            payload: payload.clone(),
+            checksum: checksum_fnv1a(&payload),
+        };
+
+        state
+            .apply_rollback_restore(&restore, 201)
+            .expect("restore");
+        assert_eq!(state.schema_version, 5);
         assert_eq!(state.migration_history().len(), 1);
         assert_eq!(
             state.migration_history()[0].direction,
@@ -1245,6 +1435,7 @@ mod tests {
         status.insert("compatibility_matrix".to_string(), true);
         status.insert("migration_path".to_string(), true);
         status.insert("rollback_snapshot".to_string(), false);
+        status.insert("rollback_payload_compatibility".to_string(), true);
         status.insert("documentation_gates".to_string(), true);
         status.insert("usage_notes".to_string(), true);
 

--- a/core/core/tests/advanced_matrix.rs
+++ b/core/core/tests/advanced_matrix.rs
@@ -1,0 +1,871 @@
+use std::collections::BTreeMap;
+use std::sync::{Arc, Mutex};
+use std::thread;
+
+use corelib::campaign::{
+    validate_prerequisite_graph, Campaign, CampaignEventPayload, CampaignId, CampaignStatus,
+    FindingSnapshot, MetadataValue, Objective, ObjectiveEvaluationEngine, ObjectiveId,
+    ObjectiveIngestionDispatcher, ObjectiveIngestionEvent, ObjectiveReevaluationTrigger,
+    ObjectiveStatus, Predicate, PredicateSnapshot, RiskLevel, RunSnapshot, SessionPrivilegeLevel,
+    SessionSnapshot,
+};
+use corelib::control::ControlState;
+use corelib::domain::{
+    Artifact, ArtifactKind, Finding, FindingSeverity, ModuleVersion, Run, RunState, Session,
+    SessionState, Task, TaskState, Workspace,
+};
+use corelib::orchestrator::{
+    DispatchOutcome, InMemoryAuditLogStore, InMemorySnapshotStore, ObservableExecutionOrchestrator,
+    OrchestratorError, PlannedTask, RunPlan, RunRequest, StaticRunPlanner, TaskExecutionContext,
+    TaskExecutionOutcome, TaskExecutionReport, TaskExecutor,
+};
+
+#[derive(Clone, Copy)]
+struct Lcg {
+    state: u64,
+}
+
+impl Lcg {
+    fn new(seed: u64) -> Self {
+        Self { state: seed }
+    }
+
+    fn next_u64(&mut self) -> u64 {
+        self.state = self
+            .state
+            .wrapping_mul(6364136223846793005)
+            .wrapping_add(1442695040888963407);
+        self.state
+    }
+
+    fn next_bool(&mut self) -> bool {
+        (self.next_u64() & 1) == 1
+    }
+
+    fn choose<T: Copy>(&mut self, values: &[T]) -> T {
+        values[(self.next_u64() as usize) % values.len()]
+    }
+}
+
+#[derive(Clone, Copy)]
+struct SnapshotFlags {
+    finding_shell: bool,
+    finding_post: bool,
+    artifact_loot: bool,
+    session_root: bool,
+    run_success: bool,
+    owner_red: bool,
+    fail_flag: bool,
+}
+
+fn deterministic_uuid(seed: u128) -> String {
+    let hex = format!("{seed:032x}");
+    format!(
+        "{}-{}-{}-{}-{}",
+        &hex[0..8],
+        &hex[8..12],
+        &hex[12..16],
+        &hex[16..20],
+        &hex[20..32]
+    )
+}
+
+fn deterministic_campaign_id(seed: u128) -> CampaignId {
+    CampaignId::parse(&deterministic_uuid(seed)).expect("campaign id")
+}
+
+fn deterministic_objective_id(seed: u128) -> ObjectiveId {
+    ObjectiveId::parse(&deterministic_uuid(seed)).expect("objective id")
+}
+
+fn build_snapshot(flags: SnapshotFlags) -> PredicateSnapshot {
+    let workspace = Workspace::new_at("ws", "advanced-matrix", 1).expect("workspace");
+    let module = ModuleVersion::new_at(
+        "exploit/linux/example",
+        "1.0.0",
+        1,
+        "builtin://example",
+        "0123456789abcdef",
+        1,
+    )
+    .expect("module");
+    let mut run = Run::new_at(workspace.id, module.id, None, "operator", 2).expect("run");
+    if flags.run_success {
+        run.transition_state(RunState::Running, 3)
+            .expect("run->running");
+        run.transition_state(RunState::Succeeded, 4)
+            .expect("run->succeeded");
+    }
+    let session = Session::new_at(run.id, None, "shell", "127.0.0.1:23", 5).expect("session");
+    let artifact = Artifact::new_at(
+        run.id,
+        None,
+        Some(session.id),
+        ArtifactKind::CommandOutput,
+        "stdout",
+        "mem://stdout",
+        6,
+    )
+    .expect("artifact");
+    let finding = Finding::new_at(
+        run.id,
+        None,
+        Some(session.id),
+        "shell found",
+        "deterministic test finding",
+        FindingSeverity::High,
+        7,
+    )
+    .expect("finding");
+    let post_finding = Finding::new_at(
+        run.id,
+        None,
+        Some(session.id),
+        "post objective",
+        "deterministic post finding",
+        FindingSeverity::Medium,
+        8,
+    )
+    .expect("post finding");
+
+    let mut snapshot = PredicateSnapshot::new().with_run(
+        RunSnapshot::new(run, "exploit/linux/example")
+            .expect("run snapshot")
+            .with_metadata(
+                "owner",
+                if flags.owner_red {
+                    MetadataValue::Text("red".to_string())
+                } else {
+                    MetadataValue::Text("blue".to_string())
+                },
+            ),
+    );
+
+    let mut artifact_snapshot = corelib::campaign::ArtifactSnapshot::new(artifact);
+    if flags.artifact_loot {
+        artifact_snapshot = artifact_snapshot.with_tag("loot");
+    }
+    snapshot = snapshot.with_artifact(artifact_snapshot);
+
+    let finding_type = if flags.finding_shell {
+        "shell_access"
+    } else {
+        "other_access"
+    };
+    snapshot = snapshot.with_finding(
+        FindingSnapshot::new(finding, finding_type)
+            .expect("finding snapshot")
+            .with_metadata(
+                "stage",
+                if flags.finding_shell {
+                    MetadataValue::Integer(1)
+                } else {
+                    MetadataValue::Integer(0)
+                },
+            ),
+    );
+    if flags.finding_post {
+        snapshot = snapshot.with_finding(
+            FindingSnapshot::new(post_finding, "post_access").expect("post finding snapshot"),
+        );
+    }
+
+    let mut session_snapshot = SessionSnapshot::new(session);
+    if flags.session_root {
+        session_snapshot = session_snapshot.with_privilege(SessionPrivilegeLevel::Root);
+    } else {
+        session_snapshot = session_snapshot.with_privilege(SessionPrivilegeLevel::User);
+    }
+    snapshot = snapshot.with_session(session_snapshot);
+
+    snapshot
+        .with_metadata(
+            "owner",
+            if flags.owner_red {
+                MetadataValue::Text("red".to_string())
+            } else {
+                MetadataValue::Text("blue".to_string())
+            },
+        )
+        .with_metadata("fail", MetadataValue::Bool(flags.fail_flag))
+}
+
+fn build_objective(
+    objective_id: ObjectiveId,
+    campaign_id: CampaignId,
+    name: &str,
+    prerequisites: Vec<ObjectiveId>,
+    success_criteria: Vec<Predicate>,
+    failure_criteria: Vec<Predicate>,
+    risk_level: RiskLevel,
+    now: u64,
+) -> Objective {
+    Objective::new_at(
+        objective_id,
+        campaign_id,
+        name,
+        "",
+        prerequisites,
+        success_criteria,
+        failure_criteria,
+        risk_level,
+        None,
+        now,
+    )
+    .expect("objective")
+}
+
+#[derive(Default)]
+struct AlwaysSuccessExecutor;
+
+impl TaskExecutor for AlwaysSuccessExecutor {
+    fn execute(
+        &mut self,
+        context: &TaskExecutionContext,
+    ) -> Result<TaskExecutionReport, OrchestratorError> {
+        Ok(TaskExecutionReport {
+            elapsed_ms: 1,
+            outcome: TaskExecutionOutcome::Success {
+                message: format!("ok:{}", context.task_name),
+            },
+        })
+    }
+}
+
+#[test]
+fn state_machine_legality_holds_under_randomized_sequences() {
+    let mut rng = Lcg::new(0xC0FFEE);
+    const RUN_STATES: [RunState; 5] = [
+        RunState::Queued,
+        RunState::Running,
+        RunState::Succeeded,
+        RunState::Failed,
+        RunState::Canceled,
+    ];
+    const TASK_STATES: [TaskState; 6] = [
+        TaskState::Queued,
+        TaskState::Running,
+        TaskState::Retrying,
+        TaskState::Succeeded,
+        TaskState::Failed,
+        TaskState::Canceled,
+    ];
+    const SESSION_STATES: [SessionState; 5] = [
+        SessionState::Opening,
+        SessionState::Open,
+        SessionState::Backgrounded,
+        SessionState::Lost,
+        SessionState::Closed,
+    ];
+    const CAMPAIGN_STATES: [CampaignStatus; 4] = [
+        CampaignStatus::Active,
+        CampaignStatus::Paused,
+        CampaignStatus::Completed,
+        CampaignStatus::Failed,
+    ];
+
+    for case in 0..64u64 {
+        let mut campaign = Campaign::new_at(
+            deterministic_campaign_id(10_000 + case as u128),
+            "op",
+            "",
+            1,
+            None,
+        )
+        .expect("campaign");
+        let workspace = Workspace::new_at("ws", "test", 1).expect("workspace");
+        let module =
+            ModuleVersion::new_at("module", "1.0.0", 1, "entry", "digest", 1).expect("module");
+        let mut run = Run::new_at(workspace.id, module.id, None, "operator", 1).expect("run");
+        let mut task = Task::new_at(run.id, "stage", 1024, 1).expect("task");
+        let mut session =
+            Session::new_at(run.id, Some(task.id), "shell", "127.0.0.1", 1).expect("session");
+
+        for step in 0..64u64 {
+            let next_campaign = rng.choose(&CAMPAIGN_STATES);
+            let campaign_expected = campaign.status.can_transition_to(next_campaign);
+            let campaign_ok = campaign.transition_status(next_campaign).is_ok();
+            assert_eq!(
+                campaign_ok, campaign_expected,
+                "campaign transition mismatch"
+            );
+
+            let next_run = rng.choose(&RUN_STATES);
+            let run_expected = run.state.can_transition_to(next_run);
+            let run_ok = run.transition_state(next_run, 2 + step).is_ok();
+            assert_eq!(run_ok, run_expected, "run transition mismatch");
+
+            let next_task = rng.choose(&TASK_STATES);
+            let task_expected = task.state.can_transition_to(next_task);
+            let task_ok = task.transition_state(next_task, 2 + step).is_ok();
+            assert_eq!(task_ok, task_expected, "task transition mismatch");
+
+            let next_session = rng.choose(&SESSION_STATES);
+            let session_expected = session.state.can_transition_to(next_session);
+            let session_ok = session.transition_state(next_session, 2 + step).is_ok();
+            assert_eq!(session_ok, session_expected, "session transition mismatch");
+        }
+    }
+}
+
+#[test]
+fn predicate_determinism_holds_for_randomized_snapshots() {
+    let mut rng = Lcg::new(0xABCD1234);
+    let predicates = vec![
+        Predicate::FindingExists {
+            finding_type: "shell_access".to_string(),
+        },
+        Predicate::SessionPrivilege {
+            level: SessionPrivilegeLevel::Root,
+        },
+        Predicate::ArtifactTagMatch {
+            tag: "loot".to_string(),
+        },
+        Predicate::RunSucceeded {
+            module_name: "exploit/linux/example".to_string(),
+        },
+        Predicate::CustomMetadataMatch {
+            key: "owner".to_string(),
+            value: MetadataValue::Text("red".to_string()),
+        },
+    ];
+
+    for _ in 0..128 {
+        let flags = SnapshotFlags {
+            finding_shell: rng.next_bool(),
+            finding_post: rng.next_bool(),
+            artifact_loot: rng.next_bool(),
+            session_root: rng.next_bool(),
+            run_success: rng.next_bool(),
+            owner_red: rng.next_bool(),
+            fail_flag: rng.next_bool(),
+        };
+        let snapshot = build_snapshot(flags);
+        let mut reversed = snapshot.clone();
+        reversed.artifacts.reverse();
+        reversed.findings.reverse();
+        reversed.sessions.reverse();
+        reversed.runs.reverse();
+
+        for predicate in &predicates {
+            let baseline = predicate.evaluate_snapshot(&snapshot);
+            for _ in 0..8 {
+                assert_eq!(baseline, predicate.evaluate_snapshot(&snapshot));
+            }
+            assert_eq!(baseline, predicate.evaluate_snapshot(&reversed));
+
+            let wire = predicate.to_wire_bytes();
+            let decoded = Predicate::from_wire_bytes(&wire).expect("predicate wire round trip");
+            assert_eq!(baseline, decoded.evaluate_snapshot(&snapshot));
+        }
+    }
+}
+
+#[test]
+fn replay_golden_trace_matches_expected_campaign_projection() {
+    let mut orchestrator = ObservableExecutionOrchestrator::new(
+        InMemorySnapshotStore::default(),
+        InMemoryAuditLogStore::default(),
+    )
+    .expect("orchestrator");
+
+    let campaign_id = deterministic_campaign_id(20_001);
+    let objective_a = deterministic_objective_id(20_101);
+    let objective_b = deterministic_objective_id(20_102);
+
+    let payloads = vec![
+        CampaignEventPayload::CampaignCreated {
+            campaign_id: campaign_id.clone(),
+            name: "golden".to_string(),
+        },
+        CampaignEventPayload::ObjectiveCreated {
+            campaign_id: campaign_id.clone(),
+            objective_id: objective_a.clone(),
+            name: "foothold".to_string(),
+            risk_level: RiskLevel::High,
+        },
+        CampaignEventPayload::ObjectiveCreated {
+            campaign_id: campaign_id.clone(),
+            objective_id: objective_b.clone(),
+            name: "post".to_string(),
+            risk_level: RiskLevel::Medium,
+        },
+        CampaignEventPayload::ObjectivePrereqLinked {
+            campaign_id: campaign_id.clone(),
+            objective_id: objective_b.clone(),
+            prerequisite_id: objective_a.clone(),
+        },
+        CampaignEventPayload::ObjectiveStatusChanged {
+            campaign_id: campaign_id.clone(),
+            objective_id: objective_a.clone(),
+            from: ObjectiveStatus::Pending,
+            to: ObjectiveStatus::Eligible,
+            reason: Some("prereq met".to_string()),
+        },
+        CampaignEventPayload::ObjectiveStatusChanged {
+            campaign_id: campaign_id.clone(),
+            objective_id: objective_a.clone(),
+            from: ObjectiveStatus::Eligible,
+            to: ObjectiveStatus::InProgress,
+            reason: Some("operator start".to_string()),
+        },
+        CampaignEventPayload::ObjectiveStatusChanged {
+            campaign_id: campaign_id.clone(),
+            objective_id: objective_a.clone(),
+            from: ObjectiveStatus::InProgress,
+            to: ObjectiveStatus::Achieved,
+            reason: Some("criteria met".to_string()),
+        },
+        CampaignEventPayload::ObjectiveStatusChanged {
+            campaign_id: campaign_id.clone(),
+            objective_id: objective_b.clone(),
+            from: ObjectiveStatus::Pending,
+            to: ObjectiveStatus::Eligible,
+            reason: Some("depends achieved".to_string()),
+        },
+        CampaignEventPayload::ObjectiveEvaluated {
+            campaign_id: campaign_id.clone(),
+            objective_id: objective_a.clone(),
+            trigger: ObjectiveReevaluationTrigger::ManualRequest,
+            prerequisites_satisfied: true,
+            success_criteria_satisfied: true,
+            failure_criteria_satisfied: false,
+            resulting_status: ObjectiveStatus::Achieved,
+        },
+        CampaignEventPayload::ObjectiveEvaluated {
+            campaign_id: campaign_id.clone(),
+            objective_id: objective_b.clone(),
+            trigger: ObjectiveReevaluationTrigger::ManualRequest,
+            prerequisites_satisfied: true,
+            success_criteria_satisfied: false,
+            failure_criteria_satisfied: false,
+            resulting_status: ObjectiveStatus::Eligible,
+        },
+    ];
+
+    orchestrator
+        .record_campaign_events(payloads.clone(), None)
+        .expect("record campaign events");
+
+    let report = orchestrator
+        .reconstruct_campaign_from_history(&campaign_id)
+        .expect("reconstruct");
+    assert!(report.diagnostics.is_empty(), "{:?}", report.diagnostics);
+    let campaign = report.campaign.expect("campaign");
+    assert_eq!(campaign.sequence_high_watermark, payloads.len() as u64);
+    assert_eq!(campaign.objective_ids.len(), 2);
+    assert_eq!(
+        campaign.objectives.get(&objective_a).expect("a").status,
+        ObjectiveStatus::Achieved
+    );
+    assert_eq!(
+        campaign.objectives.get(&objective_b).expect("b").status,
+        ObjectiveStatus::Eligible
+    );
+
+    let mut snapshot = ControlState::default();
+    let mut campaign_state =
+        Campaign::new_at(campaign_id.clone(), "golden", "", 1, None).expect("campaign");
+    campaign_state.add_objective(objective_a.clone());
+    campaign_state.add_objective(objective_b.clone());
+
+    let mut objective_state_a = build_objective(
+        objective_a.clone(),
+        campaign_id.clone(),
+        "foothold",
+        vec![],
+        vec![Predicate::FindingExists {
+            finding_type: "shell_access".to_string(),
+        }],
+        vec![],
+        RiskLevel::High,
+        1,
+    );
+    objective_state_a.status = ObjectiveStatus::Achieved;
+
+    let mut objective_state_b = build_objective(
+        objective_b.clone(),
+        campaign_id.clone(),
+        "post",
+        vec![objective_a.clone()],
+        vec![Predicate::FindingExists {
+            finding_type: "post_access".to_string(),
+        }],
+        vec![],
+        RiskLevel::Medium,
+        1,
+    );
+    objective_state_b.status = ObjectiveStatus::Eligible;
+
+    snapshot
+        .campaigns
+        .insert(campaign_id.clone(), campaign_state);
+    snapshot
+        .objectives
+        .insert(objective_a.clone(), objective_state_a);
+    snapshot
+        .objectives
+        .insert(objective_b.clone(), objective_state_b);
+
+    let consistency = orchestrator
+        .replay_campaign_consistency(&campaign_id, &snapshot)
+        .expect("consistency");
+    assert!(
+        consistency.consistent,
+        "{:?}",
+        consistency.report.diagnostics
+    );
+}
+
+#[test]
+fn restart_safety_preserves_orchestrator_progress_and_replay_state() {
+    let snapshot_shared = Arc::new(Mutex::new(None));
+    let audit_shared = Arc::new(Mutex::new(Vec::new()));
+
+    let workspace = Workspace::new_at("ws", "restart", 1).expect("workspace");
+    let module =
+        ModuleVersion::new_at("mod", "1.0.0", 1, "builtin://mod", "abc123", 1).expect("module");
+    let request = RunRequest::new(workspace.id, module.id, None, "operator").expect("request");
+    let plan = RunPlan::new(vec![
+        PlannedTask::new("stage-1", 3, 1000, "idem-stage-1").expect("task-1"),
+        PlannedTask::new("stage-2", 3, 1000, "idem-stage-2").expect("task-2"),
+    ])
+    .expect("plan");
+    let planner = StaticRunPlanner::new(plan);
+
+    let run_id = {
+        let mut orchestrator = ObservableExecutionOrchestrator::new(
+            InMemorySnapshotStore::from_shared(Arc::clone(&snapshot_shared)),
+            InMemoryAuditLogStore::from_shared(Arc::clone(&audit_shared)),
+        )
+        .expect("orchestrator");
+        let run_id = orchestrator
+            .submit_with_planner(request.clone(), &planner)
+            .expect("submit");
+        let mut executor = AlwaysSuccessExecutor;
+        let first = orchestrator.dispatch_next(&mut executor).expect("dispatch");
+        assert!(matches!(first, DispatchOutcome::Succeeded { .. }));
+        assert_eq!(orchestrator.pending_tasks(), 1);
+        run_id
+    };
+
+    let mut recovered = ObservableExecutionOrchestrator::new(
+        InMemorySnapshotStore::from_shared(Arc::clone(&snapshot_shared)),
+        InMemoryAuditLogStore::from_shared(Arc::clone(&audit_shared)),
+    )
+    .expect("recovered orchestrator");
+    assert_eq!(recovered.pending_tasks(), 1);
+    assert_eq!(recovered.run_state(run_id), Some(RunState::Running));
+
+    let mut executor = AlwaysSuccessExecutor;
+    while recovered.pending_tasks() > 0 {
+        let _ = recovered.dispatch_next(&mut executor).expect("dispatch");
+    }
+    assert_eq!(recovered.run_state(run_id), Some(RunState::Succeeded));
+
+    let replayed = recovered
+        .reconstruct_run_from_history(run_id)
+        .expect("replayed")
+        .expect("run");
+    assert_eq!(replayed.state, RunState::Succeeded);
+    assert!(replayed
+        .tasks
+        .values()
+        .all(|task| task.state == TaskState::Succeeded));
+}
+
+#[test]
+fn ingestion_dedup_is_idempotent_for_repeated_event_keys() {
+    let campaign_id = deterministic_campaign_id(30_001);
+    let objective_id = deterministic_objective_id(30_101);
+
+    let objective = build_objective(
+        objective_id.clone(),
+        campaign_id.clone(),
+        "idempotent-objective",
+        vec![],
+        vec![Predicate::FindingExists {
+            finding_type: "shell_access".to_string(),
+        }],
+        vec![],
+        RiskLevel::Low,
+        1,
+    );
+    let mut objectives = BTreeMap::from([(objective_id.clone(), objective)]);
+    let snapshot = build_snapshot(SnapshotFlags {
+        finding_shell: true,
+        finding_post: false,
+        artifact_loot: false,
+        session_root: false,
+        run_success: false,
+        owner_red: false,
+        fail_flag: false,
+    });
+    let event = ObjectiveIngestionEvent::new(
+        campaign_id.clone(),
+        ObjectiveReevaluationTrigger::FindingCreated,
+        "finding:1",
+    )
+    .expect("event");
+
+    let mut dispatcher = ObjectiveIngestionDispatcher::default();
+    let first = dispatcher
+        .dispatch(&event, &mut objectives, &snapshot, 10)
+        .expect("first");
+    let second = dispatcher
+        .dispatch(&event, &mut objectives, &snapshot, 11)
+        .expect("second");
+
+    assert!(!first.skipped_duplicate);
+    assert!(second.skipped_duplicate);
+    assert!(second.records.is_empty());
+    assert!(second.emitted_events.is_empty());
+    assert_eq!(
+        objectives.get(&objective_id).expect("objective").status,
+        ObjectiveStatus::Eligible
+    );
+}
+
+#[test]
+fn concurrent_ingestion_race_keeps_single_non_duplicate_dispatch() {
+    let campaign_id = deterministic_campaign_id(31_001);
+    let objective_id = deterministic_objective_id(31_101);
+    let objective = build_objective(
+        objective_id.clone(),
+        campaign_id.clone(),
+        "race-objective",
+        vec![],
+        vec![Predicate::FindingExists {
+            finding_type: "shell_access".to_string(),
+        }],
+        vec![],
+        RiskLevel::Low,
+        1,
+    );
+
+    let dispatcher = Arc::new(Mutex::new(ObjectiveIngestionDispatcher::default()));
+    let objectives = Arc::new(Mutex::new(BTreeMap::from([(
+        objective_id.clone(),
+        objective,
+    )])));
+    let snapshot = Arc::new(build_snapshot(SnapshotFlags {
+        finding_shell: true,
+        finding_post: false,
+        artifact_loot: false,
+        session_root: false,
+        run_success: false,
+        owner_red: false,
+        fail_flag: false,
+    }));
+    let event = Arc::new(
+        ObjectiveIngestionEvent::new(
+            campaign_id.clone(),
+            ObjectiveReevaluationTrigger::FindingCreated,
+            "finding:race",
+        )
+        .expect("event"),
+    );
+
+    let mut handles = Vec::new();
+    for thread_idx in 0..24u64 {
+        let dispatcher = Arc::clone(&dispatcher);
+        let objectives = Arc::clone(&objectives);
+        let snapshot = Arc::clone(&snapshot);
+        let event = Arc::clone(&event);
+        handles.push(thread::spawn(move || {
+            let mut dispatcher_guard = dispatcher.lock().expect("dispatcher lock");
+            let mut objective_guard = objectives.lock().expect("objectives lock");
+            dispatcher_guard
+                .dispatch(&event, &mut objective_guard, &snapshot, 100 + thread_idx)
+                .expect("dispatch")
+                .skipped_duplicate
+        }));
+    }
+
+    let skipped = handles
+        .into_iter()
+        .map(|handle| handle.join().expect("join"))
+        .collect::<Vec<_>>();
+    let non_duplicate_count = skipped.iter().filter(|value| !**value).count();
+    assert_eq!(non_duplicate_count, 1);
+
+    let objectives_guard = objectives.lock().expect("objectives lock");
+    assert_eq!(
+        objectives_guard
+            .get(&objective_id)
+            .expect("objective")
+            .status,
+        ObjectiveStatus::Eligible
+    );
+}
+
+#[test]
+fn randomized_transition_fuzz_preserves_replay_equivalence() {
+    let mut rng = Lcg::new(0xBADC0DE);
+
+    for case in 0..48u128 {
+        let campaign_id = deterministic_campaign_id(40_000 + case);
+        let objective_a = deterministic_objective_id(41_000 + (case * 2));
+        let objective_b = deterministic_objective_id(41_001 + (case * 2));
+
+        let flags = SnapshotFlags {
+            finding_shell: rng.next_bool(),
+            finding_post: rng.next_bool(),
+            artifact_loot: rng.next_bool(),
+            session_root: rng.next_bool(),
+            run_success: rng.next_bool(),
+            owner_red: rng.next_bool(),
+            fail_flag: rng.next_bool(),
+        };
+        let snapshot = build_snapshot(flags);
+
+        let mut objectives = BTreeMap::new();
+        let objective_state_a = build_objective(
+            objective_a.clone(),
+            campaign_id.clone(),
+            "phase-a",
+            vec![],
+            vec![Predicate::FindingExists {
+                finding_type: "shell_access".to_string(),
+            }],
+            vec![Predicate::CustomMetadataMatch {
+                key: "fail".to_string(),
+                value: MetadataValue::Bool(true),
+            }],
+            RiskLevel::High,
+            1,
+        );
+        let objective_state_b = build_objective(
+            objective_b.clone(),
+            campaign_id.clone(),
+            "phase-b",
+            vec![objective_a.clone()],
+            vec![Predicate::FindingExists {
+                finding_type: "post_access".to_string(),
+            }],
+            vec![Predicate::CustomMetadataMatch {
+                key: "fail".to_string(),
+                value: MetadataValue::Bool(true),
+            }],
+            RiskLevel::Medium,
+            1,
+        );
+        objectives.insert(objective_a.clone(), objective_state_a);
+        objectives.insert(objective_b.clone(), objective_state_b);
+        validate_prerequisite_graph(&objectives.values().cloned().collect::<Vec<_>>())
+            .expect("graph valid");
+
+        let mut emitted = Vec::<CampaignEventPayload>::new();
+        let _ = ObjectiveEvaluationEngine::evaluate_campaign(
+            &campaign_id,
+            &mut objectives,
+            &snapshot,
+            ObjectiveReevaluationTrigger::ManualRequest,
+            10,
+            &mut emitted,
+        )
+        .expect("initial evaluation");
+
+        let status_index = objectives
+            .iter()
+            .map(|(id, objective)| (id.clone(), objective.status))
+            .collect::<BTreeMap<_, _>>();
+        if objectives
+            .get(&objective_a)
+            .is_some_and(|objective| objective.status == ObjectiveStatus::Eligible)
+        {
+            ObjectiveEvaluationEngine::start_objective(
+                objectives.get_mut(&objective_a).expect("objective a"),
+                &status_index,
+                11,
+                &mut emitted,
+            )
+            .expect("start a");
+        }
+
+        let _ = ObjectiveEvaluationEngine::evaluate_campaign(
+            &campaign_id,
+            &mut objectives,
+            &snapshot,
+            ObjectiveReevaluationTrigger::ManualRequest,
+            12,
+            &mut emitted,
+        )
+        .expect("second evaluation");
+
+        let status_index = objectives
+            .iter()
+            .map(|(id, objective)| (id.clone(), objective.status))
+            .collect::<BTreeMap<_, _>>();
+        if objectives
+            .get(&objective_b)
+            .is_some_and(|objective| objective.status == ObjectiveStatus::Eligible)
+        {
+            ObjectiveEvaluationEngine::start_objective(
+                objectives.get_mut(&objective_b).expect("objective b"),
+                &status_index,
+                13,
+                &mut emitted,
+            )
+            .expect("start b");
+        }
+
+        let _ = ObjectiveEvaluationEngine::evaluate_campaign(
+            &campaign_id,
+            &mut objectives,
+            &snapshot,
+            ObjectiveReevaluationTrigger::ManualRequest,
+            14,
+            &mut emitted,
+        )
+        .expect("final evaluation");
+
+        let mut orchestrator = ObservableExecutionOrchestrator::new(
+            InMemorySnapshotStore::default(),
+            InMemoryAuditLogStore::default(),
+        )
+        .expect("orchestrator");
+        let mut payloads = vec![
+            CampaignEventPayload::CampaignCreated {
+                campaign_id: campaign_id.clone(),
+                name: format!("fuzz-{case}"),
+            },
+            CampaignEventPayload::ObjectiveCreated {
+                campaign_id: campaign_id.clone(),
+                objective_id: objective_a.clone(),
+                name: "phase-a".to_string(),
+                risk_level: RiskLevel::High,
+            },
+            CampaignEventPayload::ObjectiveCreated {
+                campaign_id: campaign_id.clone(),
+                objective_id: objective_b.clone(),
+                name: "phase-b".to_string(),
+                risk_level: RiskLevel::Medium,
+            },
+            CampaignEventPayload::ObjectivePrereqLinked {
+                campaign_id: campaign_id.clone(),
+                objective_id: objective_b.clone(),
+                prerequisite_id: objective_a.clone(),
+            },
+        ];
+        payloads.extend(emitted.clone());
+        orchestrator
+            .record_campaign_events(payloads, None)
+            .expect("record fuzz events");
+
+        let report = orchestrator
+            .reconstruct_campaign_from_history(&campaign_id)
+            .expect("reconstruct");
+        assert!(report.diagnostics.is_empty(), "{:?}", report.diagnostics);
+        let replayed = report.campaign.expect("campaign");
+
+        assert_eq!(
+            replayed.objectives.get(&objective_a).expect("a").status,
+            objectives.get(&objective_a).expect("a").status
+        );
+        assert_eq!(
+            replayed.objectives.get(&objective_b).expect("b").status,
+            objectives.get(&objective_b).expect("b").status
+        );
+    }
+}

--- a/core/repl/src/session.rs
+++ b/core/repl/src/session.rs
@@ -86,7 +86,7 @@ const COMMAND_HELP: &[CommandHelpSpec] = &[
         summary: "Show general help or help for one command",
         usage: "help [command]",
         aliases: &[],
-        examples: &["help", "help run", "help release"],
+        examples: &["help", "help run", "help campaign", "help objective"],
         notes: &[],
     },
     CommandHelpSpec {
@@ -213,7 +213,7 @@ const COMMAND_HELP: &[CommandHelpSpec] = &[
             "campaign list",
             "campaign status <campaign-id> paused --yes",
         ],
-        notes: &[],
+        notes: &["See docs/guide/campaign_objective_operations.md for full operator workflow."],
     },
     CommandHelpSpec {
         name: "objective",
@@ -227,6 +227,7 @@ const COMMAND_HELP: &[CommandHelpSpec] = &[
         ],
         notes: &[
             "Predicate formats: finding_exists:<type>, session_privilege:<user|elevated|root>, artifact_tag_match:<tag>, run_succeeded:<module>, custom_metadata_match:<key>=<value>",
+            "See docs/guide/campaign_objective_operations.md for detailed examples and troubleshooting.",
         ],
     },
     CommandHelpSpec {

--- a/core/repl/src/session.rs
+++ b/core/repl/src/session.rs
@@ -206,24 +206,24 @@ const COMMAND_HELP: &[CommandHelpSpec] = &[
     CommandHelpSpec {
         name: "campaign",
         summary: "Manage campaigns",
-        usage: "campaign create <name> [description] | campaign list | campaign show <campaign-id> | campaign status [campaign-id [active|paused|completed|failed]]",
+        usage: "campaign create <name> [description] [--yes] | campaign list | campaign show <campaign-id> | campaign status [campaign-id [active|paused|completed|failed] [--yes]]",
         aliases: &[],
         examples: &[
             "campaign create operation-alpha \"Internal validation operation\"",
             "campaign list",
-            "campaign status <campaign-id> paused",
+            "campaign status <campaign-id> paused --yes",
         ],
         notes: &[],
     },
     CommandHelpSpec {
         name: "objective",
         summary: "Manage objectives",
-        usage: "objective create <campaign-id> <name> --success <predicate[,predicate...]> [--failure <predicate[,predicate...]>] [--risk <low|medium|high>] [--noise-budget <n>] [--description <text>] | objective link-prereq <objective-id> <prerequisite-id> | objective list [campaign-id] | objective status [objective-id [start|evaluate]]",
+        usage: "objective create <campaign-id> <name> --success <predicate[,predicate...]> [--failure <predicate[,predicate...]>] [--risk <low|medium|high>] [--noise-budget <n>] [--description <text>] [--yes] | objective link-prereq <objective-id> <prerequisite-id> [--yes] | objective list [campaign-id] | objective status [objective-id [start|evaluate] [--yes]]",
         aliases: &[],
         examples: &[
             "objective create <campaign-id> foothold --success finding_exists:shell_access --risk high",
             "objective link-prereq <objective-id> <prerequisite-id>",
-            "objective status <objective-id> start",
+            "objective status <objective-id> start --yes",
         ],
         notes: &[
             "Predicate formats: finding_exists:<type>, session_privilege:<user|elevated|root>, artifact_tag_match:<tag>, run_succeeded:<module>, custom_metadata_match:<key>=<value>",
@@ -1917,10 +1917,16 @@ impl Repl {
             );
             return;
         }
+        let explicit_yes = has_yes_flag(tokens);
         let campaign_id = next_campaign_id();
         let name = &tokens[2];
-        let description = if tokens.len() > 3 {
-            tokens[3..].join(" ")
+        let description_parts = tokens[3..]
+            .iter()
+            .filter(|token| !is_yes_flag(token))
+            .cloned()
+            .collect::<Vec<_>>();
+        let description = if !description_parts.is_empty() {
+            description_parts.join(" ")
         } else {
             String::new()
         };
@@ -1932,6 +1938,17 @@ impl Repl {
                 return;
             }
         };
+        let decision = self
+            .policy
+            .evaluate(&PolicyRequest::create_campaign(campaign_id.as_str()));
+        if !self.enforce_policy_decision(
+            "campaign",
+            decision,
+            explicit_yes,
+            "campaign creation canceled by confirmation",
+        ) {
+            return;
+        }
         self.campaigns.insert(campaign_id.clone(), campaign.clone());
         self.emit_response(
             CommandResponse::ok("campaign", "campaign created")
@@ -2152,7 +2169,16 @@ impl Repl {
                         .with_field("status", campaign.status.as_str()),
                 );
             }
-            4 => {
+            4 | 5 => {
+                if tokens.len() == 5 && !is_yes_flag(&tokens[4]) {
+                    self.emit_error(
+                        "campaign",
+                        CliCode::Usage,
+                        "usage: campaign status [campaign-id [active|paused|completed|failed]]",
+                    );
+                    return;
+                }
+                let explicit_yes = has_yes_flag(tokens);
                 let campaign_id = match CampaignId::parse(&tokens[2]) {
                     Ok(value) => value,
                     Err(err) => {
@@ -2168,6 +2194,29 @@ impl Repl {
                     );
                     return;
                 };
+                let Some(current_status) = self.campaigns.get(&campaign_id).map(|c| c.status)
+                else {
+                    self.emit_error(
+                        "campaign",
+                        CliCode::NotFound,
+                        &format!("campaign not found: {}", campaign_id.as_str()),
+                    );
+                    return;
+                };
+                let decision = self.policy.evaluate(&PolicyRequest::change_campaign_status(
+                    campaign_id.as_str(),
+                    current_status.as_str(),
+                    next_status.as_str(),
+                ));
+                if !self.enforce_policy_decision(
+                    "campaign",
+                    decision,
+                    explicit_yes,
+                    "campaign status update canceled by confirmation",
+                ) {
+                    return;
+                }
+
                 let (campaign_id_text, from_status, to_status) = {
                     let Some(campaign) = self.campaigns.get_mut(&campaign_id) else {
                         self.emit_error(
@@ -2234,6 +2283,7 @@ impl Repl {
             );
             return;
         }
+        let explicit_yes = has_yes_flag(tokens);
         let campaign_id = match CampaignId::parse(&tokens[2]) {
             Ok(value) => value,
             Err(err) => {
@@ -2352,6 +2402,7 @@ impl Repl {
                         }
                     }
                 }
+                "--yes" | "-y" => {}
                 unknown => {
                     self.emit_error(
                         "objective",
@@ -2392,6 +2443,19 @@ impl Repl {
                 return;
             }
         };
+        let decision = self.policy.evaluate(&PolicyRequest::create_objective(
+            campaign_id.as_str(),
+            objective_id.as_str(),
+            objective.risk_level.as_str(),
+        ));
+        if !self.enforce_policy_decision(
+            "objective",
+            decision,
+            explicit_yes,
+            "objective creation canceled by confirmation",
+        ) {
+            return;
+        }
 
         self.objectives
             .insert(objective_id.clone(), objective.clone());
@@ -2409,7 +2473,7 @@ impl Repl {
     }
 
     fn cmd_objective_link_prereq(&mut self, tokens: &[String]) {
-        if tokens.len() != 4 {
+        if tokens.len() != 4 && tokens.len() != 5 {
             self.emit_error(
                 "objective",
                 CliCode::Usage,
@@ -2417,6 +2481,15 @@ impl Repl {
             );
             return;
         }
+        if tokens.len() == 5 && !is_yes_flag(&tokens[4]) {
+            self.emit_error(
+                "objective",
+                CliCode::Usage,
+                "usage: objective link-prereq <objective-id> <prerequisite-id>",
+            );
+            return;
+        }
+        let explicit_yes = has_yes_flag(tokens);
         let objective_id = match ObjectiveId::parse(&tokens[2]) {
             Ok(value) => value,
             Err(err) => {
@@ -2466,6 +2539,21 @@ impl Repl {
         }
 
         let campaign_id = objective.campaign_id.clone();
+        let decision = self
+            .policy
+            .evaluate(&PolicyRequest::link_objective_prerequisite(
+                campaign_id.as_str(),
+                objective_id.as_str(),
+                prerequisite_id.as_str(),
+            ));
+        if !self.enforce_policy_decision(
+            "objective",
+            decision,
+            explicit_yes,
+            "objective prerequisite link canceled by confirmation",
+        ) {
+            return;
+        }
         let mut already_linked = false;
         let mut inserted = false;
         if let Some(editable) = self.objectives.get_mut(&objective_id) {
@@ -2703,7 +2791,16 @@ impl Repl {
                         .with_field("status", objective.status.as_str()),
                 );
             }
-            4 => {
+            4 | 5 => {
+                if tokens.len() == 5 && !is_yes_flag(&tokens[4]) {
+                    self.emit_error(
+                        "objective",
+                        CliCode::Usage,
+                        "usage: objective status [objective-id [start|evaluate]]",
+                    );
+                    return;
+                }
+                let explicit_yes = has_yes_flag(tokens);
                 let objective_id = match ObjectiveId::parse(&tokens[2]) {
                     Ok(value) => value,
                     Err(err) => {
@@ -2712,8 +2809,8 @@ impl Repl {
                     }
                 };
                 match tokens[3].as_str() {
-                    "start" => self.cmd_objective_start(objective_id),
-                    "evaluate" => self.cmd_objective_evaluate(objective_id),
+                    "start" => self.cmd_objective_start(objective_id, explicit_yes),
+                    "evaluate" => self.cmd_objective_evaluate(objective_id, explicit_yes),
                     _ => self.emit_error(
                         "objective",
                         CliCode::Usage,
@@ -2729,7 +2826,7 @@ impl Repl {
         }
     }
 
-    fn cmd_objective_start(&mut self, objective_id: ObjectiveId) {
+    fn cmd_objective_start(&mut self, objective_id: ObjectiveId, explicit_yes: bool) {
         let Some(objective) = self.objectives.get(&objective_id) else {
             self.emit_error(
                 "objective",
@@ -2739,6 +2836,19 @@ impl Repl {
             return;
         };
         let campaign_id = objective.campaign_id.clone();
+        let decision = self.policy.evaluate(&PolicyRequest::start_objective(
+            campaign_id.as_str(),
+            objective.id.as_str(),
+            objective.risk_level.as_str(),
+        ));
+        if !self.enforce_policy_decision(
+            "objective",
+            decision,
+            explicit_yes,
+            "objective start canceled by confirmation",
+        ) {
+            return;
+        }
         let objective_statuses = self
             .objectives
             .values()
@@ -2771,11 +2881,12 @@ impl Repl {
             CommandResponse::ok("objective", "objective started")
                 .with_field("objective_id", transition.objective_id.as_str())
                 .with_field("from", transition.from.as_str())
-                .with_field("to", transition.to.as_str()),
+                .with_field("to", transition.to.as_str())
+                .with_field("campaign_id", campaign_id.as_str()),
         );
     }
 
-    fn cmd_objective_evaluate(&mut self, objective_id: ObjectiveId) {
+    fn cmd_objective_evaluate(&mut self, objective_id: ObjectiveId, explicit_yes: bool) {
         let Some(objective) = self.objectives.get(&objective_id) else {
             self.emit_error(
                 "objective",
@@ -2785,6 +2896,19 @@ impl Repl {
             return;
         };
         let campaign_id = objective.campaign_id.clone();
+        let decision = self.policy.evaluate(&PolicyRequest::evaluate_objective(
+            campaign_id.as_str(),
+            objective.id.as_str(),
+            objective.risk_level.as_str(),
+        ));
+        if !self.enforce_policy_decision(
+            "objective",
+            decision,
+            explicit_yes,
+            "objective evaluation canceled by confirmation",
+        ) {
+            return;
+        }
         let mut scoped = self
             .objectives
             .iter()
@@ -3189,6 +3313,36 @@ impl Repl {
         Ok(matches!(answer.as_str(), "yes" | "y"))
     }
 
+    fn enforce_policy_decision(
+        &self,
+        command: &str,
+        decision: corelib::policy::PolicyDecision,
+        explicit_yes: bool,
+        confirm_cancel_message: &str,
+    ) -> bool {
+        match decision.kind {
+            DecisionKind::Deny => {
+                self.emit_error(
+                    command,
+                    CliCode::PolicyDenied,
+                    &format!("policy blocked {command}: {}", decision.reason),
+                );
+                false
+            }
+            DecisionKind::RequireConfirmation if !explicit_yes => {
+                let confirmed = self
+                    .confirm_intent(&format!("{} [yes/no]: ", decision.reason))
+                    .unwrap_or(false);
+                if !confirmed {
+                    self.emit_error(command, CliCode::PolicyDenied, confirm_cancel_message);
+                    return false;
+                }
+                true
+            }
+            _ => true,
+        }
+    }
+
     fn emit_response(&self, response: CommandResponse) {
         if self.output_mode.is_json() {
             println!("{}", response.render_json());
@@ -3506,6 +3660,25 @@ impl Repl {
                                 .map(|v| v.to_string())
                                 .collect();
                         }
+                    } else if token_index == 4
+                        && matches!(tokens.get(1), Some(&"status"))
+                        && tokens
+                            .get(2)
+                            .and_then(|value| CampaignId::parse(value).ok())
+                            .is_some()
+                        && matches!(
+                            tokens.get(3),
+                            Some(&"active")
+                                | Some(&"paused")
+                                | Some(&"completed")
+                                | Some(&"failed")
+                        )
+                    {
+                        candidates = ["--yes", "-y"]
+                            .iter()
+                            .filter(|v| v.starts_with(current))
+                            .map(|v| v.to_string())
+                            .collect();
                     }
                 }
                 "objective" => {
@@ -3580,6 +3753,35 @@ impl Repl {
                                 .map(|v| v.to_string())
                                 .collect();
                             }
+                        }
+                    } else if token_index == 4 && matches!(tokens.get(1), Some(&"status")) {
+                        if tokens
+                            .get(2)
+                            .and_then(|value| ObjectiveId::parse(value).ok())
+                            .is_some()
+                            && matches!(tokens.get(3), Some(&"start") | Some(&"evaluate"))
+                        {
+                            candidates = ["--yes", "-y"]
+                                .iter()
+                                .filter(|v| v.starts_with(current))
+                                .map(|v| v.to_string())
+                                .collect();
+                        }
+                    } else if token_index == 4 && matches!(tokens.get(1), Some(&"link-prereq")) {
+                        if tokens
+                            .get(2)
+                            .and_then(|value| ObjectiveId::parse(value).ok())
+                            .is_some()
+                            && tokens
+                                .get(3)
+                                .and_then(|value| ObjectiveId::parse(value).ok())
+                                .is_some()
+                        {
+                            candidates = ["--yes", "-y"]
+                                .iter()
+                                .filter(|v| v.starts_with(current))
+                                .map(|v| v.to_string())
+                                .collect();
                         }
                     }
                 }
@@ -3758,6 +3960,14 @@ fn search_flag_candidates(prefix: &str) -> Vec<String> {
         .filter(|flag| flag.starts_with(prefix))
         .map(|flag| flag.to_string())
         .collect()
+}
+
+fn is_yes_flag(token: &str) -> bool {
+    token.eq_ignore_ascii_case("--yes") || token.eq_ignore_ascii_case("-y")
+}
+
+fn has_yes_flag(tokens: &[String]) -> bool {
+    tokens.iter().any(|token| is_yes_flag(token))
 }
 
 fn next_campaign_id() -> CampaignId {

--- a/core/repl/src/session.rs
+++ b/core/repl/src/session.rs
@@ -266,6 +266,7 @@ const COMMAND_HELP: &[CommandHelpSpec] = &[
 impl Repl {
     pub fn new(prompt: String, registry: ModuleRegistry, catalog: Option<ModuleCatalog>) -> Self {
         let module_compat = ModuleCompatibilityPolicy::catalog_default();
+        let release_migration_policy = MigrationPolicy::default_control_plane();
         let release_compat_policy = ReleaseCompatibilityPolicy::new(
             VersionWindow::new(
                 module_compat.min_manifest_version,
@@ -277,13 +278,16 @@ impl Repl {
                 module_compat.max_module_api_version,
             )
             .expect("fixed module API range"),
-            VersionWindow::new(1, 3).expect("fixed control-state range"),
+            VersionWindow::new(
+                release_migration_policy.supported_min_version,
+                release_migration_policy.latest_version,
+            )
+            .expect("fixed control-state range"),
             vec!["human".to_string(), "json".to_string()],
             vec!["builtin".to_string(), "dynlib".to_string()],
         )
         .expect("fixed release compatibility policy");
 
-        let release_migration_policy = MigrationPolicy::default_control_plane();
         let release_state =
             VersionedControlState::new(release_migration_policy.supported_min_version)
                 .expect("default schema version");
@@ -1468,7 +1472,18 @@ impl Repl {
                 self.release_migration_policy.latest_version,
             )
             .is_ok();
-        let rollback_snapshot_ok = self.release_rollback.has_snapshots();
+        let rollback_snapshots = self.release_rollback.list_snapshots();
+        let rollback_snapshot_ok = !rollback_snapshots.is_empty();
+        let rollback_payload_compatibility_ok = rollback_snapshots
+            .first()
+            .map(|snapshot| {
+                VersionedControlState::validate_snapshot_payload_compatibility(
+                    snapshot.schema_version,
+                    &snapshot.payload,
+                )
+                .is_ok()
+            })
+            .unwrap_or(false);
         let docs_usage_ok = docs_report
             .results
             .iter()
@@ -1483,6 +1498,10 @@ impl Repl {
         );
         checklist_status.insert("migration_path".to_string(), migration_path_ok);
         checklist_status.insert("rollback_snapshot".to_string(), rollback_snapshot_ok);
+        checklist_status.insert(
+            "rollback_payload_compatibility".to_string(),
+            rollback_payload_compatibility_ok,
+        );
         checklist_status.insert("documentation_gates".to_string(), docs_report.all_passed);
         checklist_status.insert("usage_notes".to_string(), docs_usage_ok);
 
@@ -1493,7 +1512,11 @@ impl Repl {
                 .with_field("compatibility_ok", matrix_report.tests_passed)
                 .with_field("docs_ok", docs_report.all_passed)
                 .with_field("migration_path_ok", migration_path_ok)
-                .with_field("rollback_snapshot_ok", rollback_snapshot_ok),
+                .with_field("rollback_snapshot_ok", rollback_snapshot_ok)
+                .with_field(
+                    "rollback_payload_compatibility_ok",
+                    rollback_payload_compatibility_ok,
+                ),
         );
 
         if self.output_mode.is_json() || checklist_report.ready {
@@ -1682,7 +1705,12 @@ impl Repl {
                 let snapshot = match self.release_rollback.create_snapshot(
                     &format!("pre-migrate-v{}-to-v{}", from_version, target_version),
                     self.release_state.schema_version,
-                    &self.release_state.snapshot_payload(),
+                    &self
+                        .release_state
+                        .snapshot_payload_with_campaign_objective_state(
+                            self.campaigns.len(),
+                            self.objectives.len(),
+                        ),
                     now_secs(),
                 ) {
                     Ok(snapshot) => snapshot,
@@ -1736,7 +1764,12 @@ impl Repl {
                 match self.release_rollback.create_snapshot(
                     &label,
                     self.release_state.schema_version,
-                    &self.release_state.snapshot_payload(),
+                    &self
+                        .release_state
+                        .snapshot_payload_with_campaign_objective_state(
+                            self.campaigns.len(),
+                            self.objectives.len(),
+                        ),
                     now_secs(),
                 ) {
                     Ok(snapshot) => self.emit_response(
@@ -1846,14 +1879,26 @@ impl Repl {
 
                 match self.release_rollback.restore(snapshot_id) {
                     Ok(restore) => {
-                        self.release_state
-                            .apply_rollback_restore(&restore, now_secs());
-                        self.emit_response(
-                            CommandResponse::ok("release", "rollback restore applied")
-                                .with_field("snapshot_id", restore.snapshot_id)
-                                .with_field("schema_version", restore.schema_version)
-                                .with_field("label", restore.label),
-                        );
+                        match self
+                            .release_state
+                            .apply_rollback_restore(&restore, now_secs())
+                        {
+                            Ok(()) => {
+                                self.emit_response(
+                                    CommandResponse::ok("release", "rollback restore applied")
+                                        .with_field("snapshot_id", restore.snapshot_id)
+                                        .with_field("schema_version", restore.schema_version)
+                                        .with_field("label", restore.label),
+                                );
+                            }
+                            Err(err) => {
+                                self.emit_error(
+                                    "release",
+                                    CliCode::Execution,
+                                    &format!("rollback restore compatibility check failed: {err}"),
+                                );
+                            }
+                        }
                     }
                     Err(err) => self.emit_error("release", CliCode::Execution, &err.to_string()),
                 }

--- a/core/repl/src/session.rs
+++ b/core/repl/src/session.rs
@@ -1,8 +1,13 @@
-use std::collections::{BTreeMap, HashSet};
+use std::collections::{BTreeMap, BTreeSet, HashSet};
 use std::io::{self, Write};
 use std::thread;
 use std::time::{Duration, Instant};
 
+use corelib::campaign::{
+    validate_prerequisite_graph, Campaign, CampaignId, MetadataValue, Objective,
+    ObjectiveEvaluationEngine, ObjectiveId, ObjectiveReevaluationTrigger, Predicate,
+    PredicateSnapshot, RiskLevel, SessionPrivilegeLevel,
+};
 use corelib::ids::Id;
 use corelib::policy::{
     Capability, DecisionKind, ModuleContext as PolicyModuleContext, PolicyEngine, PolicyRequest,
@@ -60,6 +65,8 @@ pub struct Repl {
     release_rollback: RollbackRegistry,
     release_doc_gates: DocumentationGateSuite,
     release_checklist: ReleaseChecklistTemplate,
+    campaigns: BTreeMap<CampaignId, Campaign>,
+    objectives: BTreeMap<ObjectiveId, Objective>,
     palette: Palette,
 }
 
@@ -197,6 +204,32 @@ const COMMAND_HELP: &[CommandHelpSpec] = &[
         notes: &[],
     },
     CommandHelpSpec {
+        name: "campaign",
+        summary: "Manage campaigns",
+        usage: "campaign create <name> [description] | campaign list | campaign show <campaign-id> | campaign status [campaign-id [active|paused|completed|failed]]",
+        aliases: &[],
+        examples: &[
+            "campaign create operation-alpha \"Internal validation operation\"",
+            "campaign list",
+            "campaign status <campaign-id> paused",
+        ],
+        notes: &[],
+    },
+    CommandHelpSpec {
+        name: "objective",
+        summary: "Manage objectives",
+        usage: "objective create <campaign-id> <name> --success <predicate[,predicate...]> [--failure <predicate[,predicate...]>] [--risk <low|medium|high>] [--noise-budget <n>] [--description <text>] | objective link-prereq <objective-id> <prerequisite-id> | objective list [campaign-id] | objective status [objective-id [start|evaluate]]",
+        aliases: &[],
+        examples: &[
+            "objective create <campaign-id> foothold --success finding_exists:shell_access --risk high",
+            "objective link-prereq <objective-id> <prerequisite-id>",
+            "objective status <objective-id> start",
+        ],
+        notes: &[
+            "Predicate formats: finding_exists:<type>, session_privilege:<user|elevated|root>, artifact_tag_match:<tag>, run_succeeded:<module>, custom_metadata_match:<key>=<value>",
+        ],
+    },
+    CommandHelpSpec {
         name: "sessions",
         summary: "List/read/close sessions",
         usage: "sessions | sessions -r <id> | sessions -R | sessions -k <id> [--yes] | sessions -K [--yes]",
@@ -295,6 +328,8 @@ impl Repl {
             release_rollback: RollbackRegistry::default(),
             release_doc_gates,
             release_checklist: ReleaseChecklistTemplate::default_control_plane(),
+            campaigns: BTreeMap::new(),
+            objectives: BTreeMap::new(),
             palette: Palette::new(),
         }
     }
@@ -392,6 +427,8 @@ impl Repl {
             "output" => self.cmd_output(tokens),
             "policy" => self.cmd_policy(tokens),
             "release" => self.cmd_release(tokens),
+            "campaign" => self.cmd_campaign(tokens),
+            "objective" => self.cmd_objective(tokens),
             "info" => self.cmd_info(tokens),
             "sessions" => self.cmd_sessions(tokens),
             "interact" => self.cmd_interact(tokens),
@@ -1849,6 +1886,959 @@ impl Repl {
         }
     }
 
+    fn cmd_campaign(&mut self, tokens: &[String]) {
+        if tokens.len() < 2 {
+            self.emit_error(
+                "campaign",
+                CliCode::Usage,
+                "usage: campaign create <name> [description] | campaign list | campaign show <campaign-id> | campaign status [campaign-id [active|paused|completed|failed]]",
+            );
+            return;
+        }
+        match tokens[1].as_str() {
+            "create" => self.cmd_campaign_create(tokens),
+            "list" => self.cmd_campaign_list(),
+            "show" => self.cmd_campaign_show(tokens),
+            "status" => self.cmd_campaign_status(tokens),
+            _ => self.emit_error(
+                "campaign",
+                CliCode::Usage,
+                "usage: campaign create <name> [description] | campaign list | campaign show <campaign-id> | campaign status [campaign-id [active|paused|completed|failed]]",
+            ),
+        }
+    }
+
+    fn cmd_campaign_create(&mut self, tokens: &[String]) {
+        if tokens.len() < 3 {
+            self.emit_error(
+                "campaign",
+                CliCode::Usage,
+                "usage: campaign create <name> [description]",
+            );
+            return;
+        }
+        let campaign_id = next_campaign_id();
+        let name = &tokens[2];
+        let description = if tokens.len() > 3 {
+            tokens[3..].join(" ")
+        } else {
+            String::new()
+        };
+        let now = now_secs();
+        let campaign = match Campaign::new_at(campaign_id.clone(), name, &description, now, None) {
+            Ok(value) => value,
+            Err(err) => {
+                self.emit_error("campaign", CliCode::Validation, &err.to_string());
+                return;
+            }
+        };
+        self.campaigns.insert(campaign_id.clone(), campaign.clone());
+        self.emit_response(
+            CommandResponse::ok("campaign", "campaign created")
+                .with_field("campaign_id", campaign_id.as_str())
+                .with_field("name", campaign.name)
+                .with_field("status", campaign.status.as_str()),
+        );
+    }
+
+    fn cmd_campaign_list(&self) {
+        if self.campaigns.is_empty() {
+            self.emit_response(
+                CommandResponse::ok("campaign", "no campaigns").with_field("count", 0),
+            );
+            return;
+        }
+        if self.output_mode.is_json() {
+            let campaigns_json = self
+                .campaigns
+                .values()
+                .map(|campaign| {
+                    format!(
+                        "{{\"id\":\"{}\",\"name\":\"{}\",\"status\":\"{}\",\"objective_count\":{},\"created_at\":{}}}",
+                        escape_json(campaign.id.as_str()),
+                        escape_json(&campaign.name),
+                        campaign.status.as_str(),
+                        campaign.objective_ids.len(),
+                        campaign.created_at
+                    )
+                })
+                .collect::<Vec<_>>()
+                .join(",");
+            println!(
+                "{{\"command\":\"campaign\",\"ok\":true,\"code\":\"{}\",\"message\":\"listed campaigns\",\"count\":{},\"campaigns\":[{}]}}",
+                CliCode::Ok.as_str(),
+                self.campaigns.len(),
+                campaigns_json
+            );
+            return;
+        }
+        self.emit_response(
+            CommandResponse::ok("campaign", "listed campaigns")
+                .with_field("count", self.campaigns.len()),
+        );
+
+        let headers = ["Id", "Status", "Objectives", "Created", "Name"];
+        let mut rows = Vec::with_capacity(self.campaigns.len());
+        let mut widths = [
+            headers[0].len(),
+            headers[1].len(),
+            headers[2].len(),
+            headers[3].len(),
+            headers[4].len(),
+        ];
+        for campaign in self.campaigns.values() {
+            let row = [
+                campaign.id.as_str().to_string(),
+                campaign.status.as_str().to_string(),
+                campaign.objective_ids.len().to_string(),
+                campaign.created_at.to_string(),
+                campaign.name.clone(),
+            ];
+            for (idx, col) in row.iter().enumerate() {
+                widths[idx] = widths[idx].max(col.len());
+            }
+            rows.push(row);
+        }
+
+        println!(
+            "{:<w0$}  {:<w1$}  {:<w2$}  {:<w3$}  {:<w4$}",
+            headers[0],
+            headers[1],
+            headers[2],
+            headers[3],
+            headers[4],
+            w0 = widths[0],
+            w1 = widths[1],
+            w2 = widths[2],
+            w3 = widths[3],
+            w4 = widths[4]
+        );
+        println!(
+            "{:-<w0$}  {:-<w1$}  {:-<w2$}  {:-<w3$}  {:-<w4$}",
+            "",
+            "",
+            "",
+            "",
+            "",
+            w0 = widths[0],
+            w1 = widths[1],
+            w2 = widths[2],
+            w3 = widths[3],
+            w4 = widths[4]
+        );
+        for row in rows {
+            println!(
+                "{:<w0$}  {:<w1$}  {:<w2$}  {:<w3$}  {:<w4$}",
+                row[0],
+                row[1],
+                row[2],
+                row[3],
+                row[4],
+                w0 = widths[0],
+                w1 = widths[1],
+                w2 = widths[2],
+                w3 = widths[3],
+                w4 = widths[4]
+            );
+        }
+    }
+
+    fn cmd_campaign_show(&self, tokens: &[String]) {
+        if tokens.len() != 3 {
+            self.emit_error(
+                "campaign",
+                CliCode::Usage,
+                "usage: campaign show <campaign-id>",
+            );
+            return;
+        }
+        let campaign_id = match CampaignId::parse(&tokens[2]) {
+            Ok(value) => value,
+            Err(err) => {
+                self.emit_error("campaign", CliCode::Validation, &err.to_string());
+                return;
+            }
+        };
+        let Some(campaign) = self.campaigns.get(&campaign_id) else {
+            self.emit_error(
+                "campaign",
+                CliCode::NotFound,
+                &format!("campaign not found: {}", campaign_id.as_str()),
+            );
+            return;
+        };
+        self.emit_response(
+            CommandResponse::ok("campaign", "campaign details")
+                .with_field("campaign_id", campaign.id.as_str())
+                .with_field("name", &campaign.name)
+                .with_field("status", campaign.status.as_str())
+                .with_field("objective_count", campaign.objective_ids.len()),
+        );
+        if self.output_mode.is_json() {
+            return;
+        }
+        println!("Description: {}", campaign.description);
+        println!("Created At:  {}", campaign.created_at);
+        if campaign.objective_ids.is_empty() {
+            println!("Objectives:  <none>");
+        } else {
+            let objectives = campaign
+                .objective_ids
+                .iter()
+                .map(|id| id.as_str().to_string())
+                .collect::<Vec<_>>()
+                .join(", ");
+            println!("Objectives:  {objectives}");
+        }
+    }
+
+    fn cmd_campaign_status(&mut self, tokens: &[String]) {
+        match tokens.len() {
+            2 => {
+                if self.campaigns.is_empty() {
+                    self.emit_response(
+                        CommandResponse::ok("campaign", "no campaigns").with_field("count", 0),
+                    );
+                    return;
+                }
+                if self.output_mode.is_json() {
+                    let statuses = self
+                        .campaigns
+                        .values()
+                        .map(|campaign| {
+                            format!(
+                                "{{\"campaign_id\":\"{}\",\"status\":\"{}\"}}",
+                                escape_json(campaign.id.as_str()),
+                                campaign.status.as_str()
+                            )
+                        })
+                        .collect::<Vec<_>>()
+                        .join(",");
+                    println!(
+                        "{{\"command\":\"campaign\",\"ok\":true,\"code\":\"{}\",\"message\":\"campaign statuses\",\"count\":{},\"statuses\":[{}]}}",
+                        CliCode::Ok.as_str(),
+                        self.campaigns.len(),
+                        statuses
+                    );
+                    return;
+                }
+                self.emit_response(
+                    CommandResponse::ok("campaign", "campaign statuses")
+                        .with_field("count", self.campaigns.len()),
+                );
+                for campaign in self.campaigns.values() {
+                    println!("{} {}", campaign.id.as_str(), campaign.status.as_str());
+                }
+            }
+            3 => {
+                let campaign_id = match CampaignId::parse(&tokens[2]) {
+                    Ok(value) => value,
+                    Err(err) => {
+                        self.emit_error("campaign", CliCode::Validation, &err.to_string());
+                        return;
+                    }
+                };
+                let Some(campaign) = self.campaigns.get(&campaign_id) else {
+                    self.emit_error(
+                        "campaign",
+                        CliCode::NotFound,
+                        &format!("campaign not found: {}", campaign_id.as_str()),
+                    );
+                    return;
+                };
+                self.emit_response(
+                    CommandResponse::ok("campaign", "campaign status")
+                        .with_field("campaign_id", campaign.id.as_str())
+                        .with_field("status", campaign.status.as_str()),
+                );
+            }
+            4 => {
+                let campaign_id = match CampaignId::parse(&tokens[2]) {
+                    Ok(value) => value,
+                    Err(err) => {
+                        self.emit_error("campaign", CliCode::Validation, &err.to_string());
+                        return;
+                    }
+                };
+                let Some(next_status) = parse_campaign_status_token(&tokens[3]) else {
+                    self.emit_error(
+                        "campaign",
+                        CliCode::Validation,
+                        "status must be one of: active|paused|completed|failed",
+                    );
+                    return;
+                };
+                let (campaign_id_text, from_status, to_status) = {
+                    let Some(campaign) = self.campaigns.get_mut(&campaign_id) else {
+                        self.emit_error(
+                            "campaign",
+                            CliCode::NotFound,
+                            &format!("campaign not found: {}", campaign_id.as_str()),
+                        );
+                        return;
+                    };
+                    let from = campaign.status;
+                    if let Err(err) = campaign.transition_status(next_status) {
+                        self.emit_error("campaign", CliCode::Validation, &err.to_string());
+                        return;
+                    }
+                    (
+                        campaign.id.as_str().to_string(),
+                        from.as_str().to_string(),
+                        campaign.status.as_str().to_string(),
+                    )
+                };
+                self.emit_response(
+                    CommandResponse::ok("campaign", "campaign status updated")
+                        .with_field("campaign_id", campaign_id_text)
+                        .with_field("from", from_status)
+                        .with_field("to", to_status),
+                );
+            }
+            _ => self.emit_error(
+                "campaign",
+                CliCode::Usage,
+                "usage: campaign status [campaign-id [active|paused|completed|failed]]",
+            ),
+        }
+    }
+
+    fn cmd_objective(&mut self, tokens: &[String]) {
+        if tokens.len() < 2 {
+            self.emit_error(
+                "objective",
+                CliCode::Usage,
+                "usage: objective create <campaign-id> <name> --success <predicate[,predicate...]> [--failure <predicate[,predicate...]>] [--risk <low|medium|high>] [--noise-budget <n>] [--description <text>] | objective link-prereq <objective-id> <prerequisite-id> | objective list [campaign-id] | objective status [objective-id [start|evaluate]]",
+            );
+            return;
+        }
+        match tokens[1].as_str() {
+            "create" => self.cmd_objective_create(tokens),
+            "link-prereq" => self.cmd_objective_link_prereq(tokens),
+            "list" => self.cmd_objective_list(tokens),
+            "status" => self.cmd_objective_status(tokens),
+            _ => self.emit_error(
+                "objective",
+                CliCode::Usage,
+                "usage: objective create <campaign-id> <name> --success <predicate[,predicate...]> [--failure <predicate[,predicate...]>] [--risk <low|medium|high>] [--noise-budget <n>] [--description <text>] | objective link-prereq <objective-id> <prerequisite-id> | objective list [campaign-id] | objective status [objective-id [start|evaluate]]",
+            ),
+        }
+    }
+
+    fn cmd_objective_create(&mut self, tokens: &[String]) {
+        if tokens.len() < 5 {
+            self.emit_error(
+                "objective",
+                CliCode::Usage,
+                "usage: objective create <campaign-id> <name> --success <predicate[,predicate...]> [--failure <predicate[,predicate...]>] [--risk <low|medium|high>] [--noise-budget <n>] [--description <text>]",
+            );
+            return;
+        }
+        let campaign_id = match CampaignId::parse(&tokens[2]) {
+            Ok(value) => value,
+            Err(err) => {
+                self.emit_error("objective", CliCode::Validation, &err.to_string());
+                return;
+            }
+        };
+        let Some(campaign) = self.campaigns.get(&campaign_id) else {
+            self.emit_error(
+                "objective",
+                CliCode::NotFound,
+                &format!("campaign not found: {}", campaign_id.as_str()),
+            );
+            return;
+        };
+        if campaign.status.is_terminal() {
+            self.emit_error(
+                "objective",
+                CliCode::Validation,
+                "cannot add objectives to terminal campaign",
+            );
+            return;
+        }
+
+        let name = &tokens[3];
+        let mut description = String::new();
+        let mut risk_level = RiskLevel::Medium;
+        let mut noise_budget = None;
+        let mut success_criteria = Vec::new();
+        let mut failure_criteria = Vec::new();
+
+        let mut idx = 4;
+        while idx < tokens.len() {
+            match tokens[idx].as_str() {
+                "--description" | "-d" => {
+                    idx = idx.saturating_add(1);
+                    let Some(value) = tokens.get(idx) else {
+                        self.emit_error("objective", CliCode::Usage, "usage: --description <text>");
+                        return;
+                    };
+                    description = value.clone();
+                }
+                "--risk" => {
+                    idx = idx.saturating_add(1);
+                    let Some(value) = tokens.get(idx) else {
+                        self.emit_error("objective", CliCode::Usage, "usage: --risk <level>");
+                        return;
+                    };
+                    let Some(parsed) = parse_risk_level_token(value) else {
+                        self.emit_error(
+                            "objective",
+                            CliCode::Validation,
+                            "risk must be one of: low|medium|high",
+                        );
+                        return;
+                    };
+                    risk_level = parsed;
+                }
+                "--noise-budget" => {
+                    idx = idx.saturating_add(1);
+                    let Some(value) = tokens.get(idx) else {
+                        self.emit_error("objective", CliCode::Usage, "usage: --noise-budget <n>");
+                        return;
+                    };
+                    let Ok(parsed) = value.parse::<u32>() else {
+                        self.emit_error(
+                            "objective",
+                            CliCode::Validation,
+                            "noise-budget must be a positive integer",
+                        );
+                        return;
+                    };
+                    if parsed == 0 {
+                        self.emit_error(
+                            "objective",
+                            CliCode::Validation,
+                            "noise-budget must be greater than zero",
+                        );
+                        return;
+                    }
+                    noise_budget = Some(parsed);
+                }
+                "--success" => {
+                    idx = idx.saturating_add(1);
+                    let Some(value) = tokens.get(idx) else {
+                        self.emit_error(
+                            "objective",
+                            CliCode::Usage,
+                            "usage: --success <predicate[,predicate...]>",
+                        );
+                        return;
+                    };
+                    match parse_predicates(value) {
+                        Ok(parsed) => success_criteria.extend(parsed),
+                        Err(err) => {
+                            self.emit_error("objective", CliCode::Validation, &err);
+                            return;
+                        }
+                    }
+                }
+                "--failure" => {
+                    idx = idx.saturating_add(1);
+                    let Some(value) = tokens.get(idx) else {
+                        self.emit_error(
+                            "objective",
+                            CliCode::Usage,
+                            "usage: --failure <predicate[,predicate...]>",
+                        );
+                        return;
+                    };
+                    match parse_predicates(value) {
+                        Ok(parsed) => failure_criteria.extend(parsed),
+                        Err(err) => {
+                            self.emit_error("objective", CliCode::Validation, &err);
+                            return;
+                        }
+                    }
+                }
+                unknown => {
+                    self.emit_error(
+                        "objective",
+                        CliCode::Usage,
+                        &format!("unknown argument: {unknown}"),
+                    );
+                    return;
+                }
+            }
+            idx = idx.saturating_add(1);
+        }
+
+        if success_criteria.is_empty() {
+            self.emit_error(
+                "objective",
+                CliCode::Validation,
+                "objective requires at least one success predicate (--success)",
+            );
+            return;
+        }
+
+        let objective_id = next_objective_id();
+        let objective = match Objective::new_at(
+            objective_id.clone(),
+            campaign_id.clone(),
+            name,
+            &description,
+            Vec::new(),
+            success_criteria,
+            failure_criteria,
+            risk_level,
+            noise_budget,
+            now_secs(),
+        ) {
+            Ok(value) => value,
+            Err(err) => {
+                self.emit_error("objective", CliCode::Validation, &err.to_string());
+                return;
+            }
+        };
+
+        self.objectives
+            .insert(objective_id.clone(), objective.clone());
+        if let Some(campaign) = self.campaigns.get_mut(&campaign_id) {
+            campaign.add_objective(objective_id.clone());
+        }
+
+        self.emit_response(
+            CommandResponse::ok("objective", "objective created")
+                .with_field("objective_id", objective_id.as_str())
+                .with_field("campaign_id", campaign_id.as_str())
+                .with_field("status", objective.status.as_str())
+                .with_field("risk_level", objective.risk_level.as_str()),
+        );
+    }
+
+    fn cmd_objective_link_prereq(&mut self, tokens: &[String]) {
+        if tokens.len() != 4 {
+            self.emit_error(
+                "objective",
+                CliCode::Usage,
+                "usage: objective link-prereq <objective-id> <prerequisite-id>",
+            );
+            return;
+        }
+        let objective_id = match ObjectiveId::parse(&tokens[2]) {
+            Ok(value) => value,
+            Err(err) => {
+                self.emit_error("objective", CliCode::Validation, &err.to_string());
+                return;
+            }
+        };
+        let prerequisite_id = match ObjectiveId::parse(&tokens[3]) {
+            Ok(value) => value,
+            Err(err) => {
+                self.emit_error("objective", CliCode::Validation, &err.to_string());
+                return;
+            }
+        };
+        if objective_id == prerequisite_id {
+            self.emit_error(
+                "objective",
+                CliCode::Validation,
+                "objective cannot depend on itself",
+            );
+            return;
+        }
+
+        let Some(objective) = self.objectives.get(&objective_id) else {
+            self.emit_error(
+                "objective",
+                CliCode::NotFound,
+                &format!("objective not found: {}", objective_id.as_str()),
+            );
+            return;
+        };
+        let Some(prerequisite) = self.objectives.get(&prerequisite_id) else {
+            self.emit_error(
+                "objective",
+                CliCode::NotFound,
+                &format!("objective not found: {}", prerequisite_id.as_str()),
+            );
+            return;
+        };
+        if objective.campaign_id != prerequisite.campaign_id {
+            self.emit_error(
+                "objective",
+                CliCode::Validation,
+                "objective and prerequisite must belong to same campaign",
+            );
+            return;
+        }
+
+        let campaign_id = objective.campaign_id.clone();
+        let mut already_linked = false;
+        let mut inserted = false;
+        if let Some(editable) = self.objectives.get_mut(&objective_id) {
+            if editable.prerequisites.contains(&prerequisite_id) {
+                already_linked = true;
+            } else {
+                editable.prerequisites.push(prerequisite_id.clone());
+                editable.updated_at = now_secs();
+                inserted = true;
+            }
+        }
+
+        if already_linked {
+            self.emit_response(
+                CommandResponse::ok("objective", "prerequisite already linked")
+                    .with_field("objective_id", objective_id.as_str())
+                    .with_field("prerequisite_id", prerequisite_id.as_str()),
+            );
+            return;
+        }
+
+        let validation = self.validate_campaign_objective_graph(&campaign_id);
+        if let Err(err) = validation {
+            if inserted {
+                if let Some(editable) = self.objectives.get_mut(&objective_id) {
+                    editable.prerequisites.retain(|id| id != &prerequisite_id);
+                    editable.updated_at = now_secs();
+                }
+            }
+            self.emit_error("objective", CliCode::Validation, &err.to_string());
+            return;
+        }
+
+        self.emit_response(
+            CommandResponse::ok("objective", "prerequisite linked")
+                .with_field("objective_id", objective_id.as_str())
+                .with_field("prerequisite_id", prerequisite_id.as_str()),
+        );
+    }
+
+    fn cmd_objective_list(&self, tokens: &[String]) {
+        if tokens.len() > 3 {
+            self.emit_error(
+                "objective",
+                CliCode::Usage,
+                "usage: objective list [campaign-id]",
+            );
+            return;
+        }
+        let filter_campaign = if tokens.len() == 3 {
+            match CampaignId::parse(&tokens[2]) {
+                Ok(value) => Some(value),
+                Err(err) => {
+                    self.emit_error("objective", CliCode::Validation, &err.to_string());
+                    return;
+                }
+            }
+        } else {
+            None
+        };
+
+        let objectives = self
+            .objectives
+            .values()
+            .filter(|objective| {
+                filter_campaign
+                    .as_ref()
+                    .map(|campaign_id| &objective.campaign_id == campaign_id)
+                    .unwrap_or(true)
+            })
+            .collect::<Vec<_>>();
+
+        if objectives.is_empty() {
+            self.emit_response(
+                CommandResponse::ok("objective", "no objectives")
+                    .with_field("count", 0)
+                    .with_field(
+                        "campaign_id",
+                        filter_campaign
+                            .as_ref()
+                            .map(|id| id.as_str().to_string())
+                            .unwrap_or_default(),
+                    ),
+            );
+            return;
+        }
+        if self.output_mode.is_json() {
+            let objectives_json = objectives
+                .iter()
+                .map(|objective| {
+                    format!(
+                        "{{\"id\":\"{}\",\"campaign_id\":\"{}\",\"name\":\"{}\",\"status\":\"{}\",\"risk\":\"{}\",\"prerequisites\":{}}}",
+                        escape_json(objective.id.as_str()),
+                        escape_json(objective.campaign_id.as_str()),
+                        escape_json(&objective.name),
+                        objective.status.as_str(),
+                        objective.risk_level.as_str(),
+                        objective.prerequisites.len()
+                    )
+                })
+                .collect::<Vec<_>>()
+                .join(",");
+            println!(
+                "{{\"command\":\"objective\",\"ok\":true,\"code\":\"{}\",\"message\":\"listed objectives\",\"count\":{},\"objectives\":[{}]}}",
+                CliCode::Ok.as_str(),
+                objectives.len(),
+                objectives_json
+            );
+            return;
+        }
+        self.emit_response(
+            CommandResponse::ok("objective", "listed objectives")
+                .with_field("count", objectives.len()),
+        );
+
+        let headers = ["Id", "Campaign", "Status", "Risk", "Prereq", "Name"];
+        let mut rows = Vec::with_capacity(objectives.len());
+        let mut widths = [
+            headers[0].len(),
+            headers[1].len(),
+            headers[2].len(),
+            headers[3].len(),
+            headers[4].len(),
+            headers[5].len(),
+        ];
+        for objective in objectives {
+            let row = [
+                objective.id.as_str().to_string(),
+                objective.campaign_id.as_str().to_string(),
+                objective.status.as_str().to_string(),
+                objective.risk_level.as_str().to_string(),
+                objective.prerequisites.len().to_string(),
+                objective.name.clone(),
+            ];
+            for (idx, col) in row.iter().enumerate() {
+                widths[idx] = widths[idx].max(col.len());
+            }
+            rows.push(row);
+        }
+
+        println!(
+            "{:<w0$}  {:<w1$}  {:<w2$}  {:<w3$}  {:<w4$}  {:<w5$}",
+            headers[0],
+            headers[1],
+            headers[2],
+            headers[3],
+            headers[4],
+            headers[5],
+            w0 = widths[0],
+            w1 = widths[1],
+            w2 = widths[2],
+            w3 = widths[3],
+            w4 = widths[4],
+            w5 = widths[5]
+        );
+        println!(
+            "{:-<w0$}  {:-<w1$}  {:-<w2$}  {:-<w3$}  {:-<w4$}  {:-<w5$}",
+            "",
+            "",
+            "",
+            "",
+            "",
+            "",
+            w0 = widths[0],
+            w1 = widths[1],
+            w2 = widths[2],
+            w3 = widths[3],
+            w4 = widths[4],
+            w5 = widths[5]
+        );
+        for row in rows {
+            println!(
+                "{:<w0$}  {:<w1$}  {:<w2$}  {:<w3$}  {:<w4$}  {:<w5$}",
+                row[0],
+                row[1],
+                row[2],
+                row[3],
+                row[4],
+                row[5],
+                w0 = widths[0],
+                w1 = widths[1],
+                w2 = widths[2],
+                w3 = widths[3],
+                w4 = widths[4],
+                w5 = widths[5]
+            );
+        }
+    }
+
+    fn cmd_objective_status(&mut self, tokens: &[String]) {
+        match tokens.len() {
+            2 => {
+                let mut counts = BTreeMap::<&'static str, usize>::new();
+                counts.insert("pending", 0);
+                counts.insert("eligible", 0);
+                counts.insert("in_progress", 0);
+                counts.insert("achieved", 0);
+                counts.insert("failed", 0);
+                for objective in self.objectives.values() {
+                    let key = objective.status.as_str();
+                    if let Some(counter) = counts.get_mut(key) {
+                        *counter = counter.saturating_add(1);
+                    }
+                }
+                self.emit_response(
+                    CommandResponse::ok("objective", "objective status counts")
+                        .with_field("total", self.objectives.len())
+                        .with_field("pending", counts["pending"])
+                        .with_field("eligible", counts["eligible"])
+                        .with_field("in_progress", counts["in_progress"])
+                        .with_field("achieved", counts["achieved"])
+                        .with_field("failed", counts["failed"]),
+                );
+            }
+            3 => {
+                let objective_id = match ObjectiveId::parse(&tokens[2]) {
+                    Ok(value) => value,
+                    Err(err) => {
+                        self.emit_error("objective", CliCode::Validation, &err.to_string());
+                        return;
+                    }
+                };
+                let Some(objective) = self.objectives.get(&objective_id) else {
+                    self.emit_error(
+                        "objective",
+                        CliCode::NotFound,
+                        &format!("objective not found: {}", objective_id.as_str()),
+                    );
+                    return;
+                };
+                self.emit_response(
+                    CommandResponse::ok("objective", "objective status")
+                        .with_field("objective_id", objective.id.as_str())
+                        .with_field("campaign_id", objective.campaign_id.as_str())
+                        .with_field("status", objective.status.as_str()),
+                );
+            }
+            4 => {
+                let objective_id = match ObjectiveId::parse(&tokens[2]) {
+                    Ok(value) => value,
+                    Err(err) => {
+                        self.emit_error("objective", CliCode::Validation, &err.to_string());
+                        return;
+                    }
+                };
+                match tokens[3].as_str() {
+                    "start" => self.cmd_objective_start(objective_id),
+                    "evaluate" => self.cmd_objective_evaluate(objective_id),
+                    _ => self.emit_error(
+                        "objective",
+                        CliCode::Usage,
+                        "usage: objective status [objective-id [start|evaluate]]",
+                    ),
+                }
+            }
+            _ => self.emit_error(
+                "objective",
+                CliCode::Usage,
+                "usage: objective status [objective-id [start|evaluate]]",
+            ),
+        }
+    }
+
+    fn cmd_objective_start(&mut self, objective_id: ObjectiveId) {
+        let Some(objective) = self.objectives.get(&objective_id) else {
+            self.emit_error(
+                "objective",
+                CliCode::NotFound,
+                &format!("objective not found: {}", objective_id.as_str()),
+            );
+            return;
+        };
+        let campaign_id = objective.campaign_id.clone();
+        let objective_statuses = self
+            .objectives
+            .values()
+            .filter(|objective| objective.campaign_id == campaign_id)
+            .map(|objective| (objective.id.clone(), objective.status))
+            .collect::<BTreeMap<_, _>>();
+
+        let Some(editable) = self.objectives.get_mut(&objective_id) else {
+            self.emit_error(
+                "objective",
+                CliCode::NotFound,
+                &format!("objective not found: {}", objective_id.as_str()),
+            );
+            return;
+        };
+        let mut events = Vec::new();
+        let transition = match ObjectiveEvaluationEngine::start_objective(
+            editable,
+            &objective_statuses,
+            now_secs(),
+            &mut events,
+        ) {
+            Ok(value) => value,
+            Err(err) => {
+                self.emit_error("objective", CliCode::Validation, &err.to_string());
+                return;
+            }
+        };
+        self.emit_response(
+            CommandResponse::ok("objective", "objective started")
+                .with_field("objective_id", transition.objective_id.as_str())
+                .with_field("from", transition.from.as_str())
+                .with_field("to", transition.to.as_str()),
+        );
+    }
+
+    fn cmd_objective_evaluate(&mut self, objective_id: ObjectiveId) {
+        let Some(objective) = self.objectives.get(&objective_id) else {
+            self.emit_error(
+                "objective",
+                CliCode::NotFound,
+                &format!("objective not found: {}", objective_id.as_str()),
+            );
+            return;
+        };
+        let campaign_id = objective.campaign_id.clone();
+        let mut scoped = self
+            .objectives
+            .iter()
+            .filter(|(_, objective)| objective.campaign_id == campaign_id)
+            .map(|(id, objective)| (id.clone(), objective.clone()))
+            .collect::<BTreeMap<_, _>>();
+        let selected = BTreeSet::from([objective_id.clone()]);
+        let snapshot = PredicateSnapshot::default();
+        let mut events = Vec::new();
+        let records = match ObjectiveEvaluationEngine::evaluate_selected(
+            &mut scoped,
+            &selected,
+            &snapshot,
+            ObjectiveReevaluationTrigger::ManualRequest,
+            now_secs(),
+            &mut events,
+        ) {
+            Ok(value) => value,
+            Err(err) => {
+                self.emit_error("objective", CliCode::Validation, &err.to_string());
+                return;
+            }
+        };
+
+        for (id, objective) in scoped {
+            self.objectives.insert(id, objective);
+        }
+
+        let Some(updated) = self.objectives.get(&objective_id) else {
+            self.emit_error("objective", CliCode::Execution, "objective evaluate failed");
+            return;
+        };
+        let evaluations = records.len();
+        self.emit_response(
+            CommandResponse::ok("objective", "objective evaluated")
+                .with_field("objective_id", updated.id.as_str())
+                .with_field("status", updated.status.as_str())
+                .with_field("evaluations", evaluations),
+        );
+    }
+
+    fn validate_campaign_objective_graph(
+        &self,
+        campaign_id: &CampaignId,
+    ) -> Result<(), corelib::campaign::CampaignModelError> {
+        let objectives = self
+            .objectives
+            .values()
+            .filter(|objective| &objective.campaign_id == campaign_id)
+            .cloned()
+            .collect::<Vec<_>>();
+        validate_prerequisite_graph(&objectives)
+    }
+
     fn build_release_matrix(&self) -> CompatibilityMatrix {
         let manifest_min = self.release_compat_policy.module_manifest_versions.min;
         let manifest_max = self.release_compat_policy.module_manifest_versions.max;
@@ -2484,6 +3474,115 @@ impl Repl {
                             .collect();
                     }
                 }
+                "campaign" => {
+                    if token_index == 1 {
+                        candidates = ["create", "list", "show", "status"]
+                            .iter()
+                            .filter(|v| v.starts_with(current))
+                            .map(|v| v.to_string())
+                            .collect();
+                    } else if token_index == 2 {
+                        if matches!(tokens.get(1), Some(&"show")) {
+                            candidates = campaign_id_candidates(self, current);
+                        } else if matches!(tokens.get(1), Some(&"status")) {
+                            let mut status_candidates = ["active", "paused", "completed", "failed"]
+                                .iter()
+                                .filter(|v| v.starts_with(current))
+                                .map(|v| v.to_string())
+                                .collect::<Vec<_>>();
+                            let mut id_candidates = campaign_id_candidates(self, current);
+                            status_candidates.append(&mut id_candidates);
+                            candidates = status_candidates;
+                        }
+                    } else if token_index == 3 && matches!(tokens.get(1), Some(&"status")) {
+                        if tokens
+                            .get(2)
+                            .and_then(|value| CampaignId::parse(value).ok())
+                            .is_some()
+                        {
+                            candidates = ["active", "paused", "completed", "failed"]
+                                .iter()
+                                .filter(|v| v.starts_with(current))
+                                .map(|v| v.to_string())
+                                .collect();
+                        }
+                    }
+                }
+                "objective" => {
+                    if token_index == 1 {
+                        candidates = ["create", "link-prereq", "list", "status"]
+                            .iter()
+                            .filter(|v| v.starts_with(current))
+                            .map(|v| v.to_string())
+                            .collect();
+                    } else if token_index == 2 {
+                        if matches!(tokens.get(1), Some(&"create") | Some(&"list")) {
+                            candidates = campaign_id_candidates(self, current);
+                        } else if matches!(tokens.get(1), Some(&"link-prereq") | Some(&"status")) {
+                            candidates = objective_id_candidates(self, current);
+                        }
+                    } else if token_index == 3 {
+                        if matches!(tokens.get(1), Some(&"link-prereq")) {
+                            candidates = objective_id_candidates(self, current);
+                        } else if matches!(tokens.get(1), Some(&"status")) {
+                            if tokens
+                                .get(2)
+                                .and_then(|value| ObjectiveId::parse(value).ok())
+                                .is_some()
+                            {
+                                candidates = ["start", "evaluate"]
+                                    .iter()
+                                    .filter(|v| v.starts_with(current))
+                                    .map(|v| v.to_string())
+                                    .collect();
+                            }
+                        } else if matches!(tokens.get(1), Some(&"create")) {
+                            candidates = [
+                                "--success",
+                                "--failure",
+                                "--risk",
+                                "--noise-budget",
+                                "--description",
+                                "-d",
+                            ]
+                            .iter()
+                            .filter(|v| v.starts_with(current))
+                            .map(|v| v.to_string())
+                            .collect();
+                        }
+                    } else if token_index >= 4 && matches!(tokens.get(1), Some(&"create")) {
+                        match tokens.get(token_index.saturating_sub(1)) {
+                            Some(&"--risk") => {
+                                candidates = ["low", "medium", "high"]
+                                    .iter()
+                                    .filter(|v| v.starts_with(current))
+                                    .map(|v| v.to_string())
+                                    .collect();
+                            }
+                            Some(&"--noise-budget") => {
+                                candidates = ["1", "10", "100"]
+                                    .iter()
+                                    .filter(|v| v.starts_with(current))
+                                    .map(|v| v.to_string())
+                                    .collect();
+                            }
+                            _ => {
+                                candidates = [
+                                    "--success",
+                                    "--failure",
+                                    "--risk",
+                                    "--noise-budget",
+                                    "--description",
+                                    "-d",
+                                ]
+                                .iter()
+                                .filter(|v| v.starts_with(current))
+                                .map(|v| v.to_string())
+                                .collect();
+                            }
+                        }
+                    }
+                }
                 "interact" => {
                     if token_index == 1 {
                         candidates = session_id_candidates(self, current);
@@ -2620,6 +3719,22 @@ fn session_id_candidates(repl: &Repl, prefix: &str) -> Vec<String> {
         .collect()
 }
 
+fn campaign_id_candidates(repl: &Repl, prefix: &str) -> Vec<String> {
+    repl.campaigns
+        .keys()
+        .map(|id| id.as_str().to_string())
+        .filter(|id| id.starts_with(prefix))
+        .collect()
+}
+
+fn objective_id_candidates(repl: &Repl, prefix: &str) -> Vec<String> {
+    repl.objectives
+        .keys()
+        .map(|id| id.as_str().to_string())
+        .filter(|id| id.starts_with(prefix))
+        .collect()
+}
+
 fn release_snapshot_id_candidates(repl: &Repl, prefix: &str) -> Vec<String> {
     repl.release_rollback
         .list_snapshots()
@@ -2643,6 +3758,148 @@ fn search_flag_candidates(prefix: &str) -> Vec<String> {
         .filter(|flag| flag.starts_with(prefix))
         .map(|flag| flag.to_string())
         .collect()
+}
+
+fn next_campaign_id() -> CampaignId {
+    let left = Id::next().0;
+    let right = Id::next().0;
+    let hex = format!("{left:016x}{right:016x}");
+    let raw = format!(
+        "{}-{}-{}-{}-{}",
+        &hex[0..8],
+        &hex[8..12],
+        &hex[12..16],
+        &hex[16..20],
+        &hex[20..32]
+    );
+    CampaignId::parse(&raw).expect("generated campaign id must be valid")
+}
+
+fn next_objective_id() -> ObjectiveId {
+    let left = Id::next().0;
+    let right = Id::next().0;
+    let hex = format!("{left:016x}{right:016x}");
+    let raw = format!(
+        "{}-{}-{}-{}-{}",
+        &hex[0..8],
+        &hex[8..12],
+        &hex[12..16],
+        &hex[16..20],
+        &hex[20..32]
+    );
+    ObjectiveId::parse(&raw).expect("generated objective id must be valid")
+}
+
+fn parse_campaign_status_token(raw: &str) -> Option<corelib::campaign::CampaignStatus> {
+    match raw.trim().to_ascii_lowercase().as_str() {
+        "active" => Some(corelib::campaign::CampaignStatus::Active),
+        "paused" => Some(corelib::campaign::CampaignStatus::Paused),
+        "completed" => Some(corelib::campaign::CampaignStatus::Completed),
+        "failed" => Some(corelib::campaign::CampaignStatus::Failed),
+        _ => None,
+    }
+}
+
+fn parse_risk_level_token(raw: &str) -> Option<RiskLevel> {
+    match raw.trim().to_ascii_lowercase().as_str() {
+        "low" => Some(RiskLevel::Low),
+        "medium" => Some(RiskLevel::Medium),
+        "high" => Some(RiskLevel::High),
+        _ => None,
+    }
+}
+
+fn parse_predicates(raw: &str) -> Result<Vec<Predicate>, String> {
+    let mut predicates = Vec::new();
+    for item in raw.split(',') {
+        let token = item.trim();
+        if token.is_empty() {
+            continue;
+        }
+        predicates.push(parse_predicate(token)?);
+    }
+    if predicates.is_empty() {
+        return Err("predicate list cannot be empty".to_string());
+    }
+    Ok(predicates)
+}
+
+fn parse_predicate(raw: &str) -> Result<Predicate, String> {
+    if let Some(rest) = raw.strip_prefix("finding_exists:") {
+        let finding_type = rest.trim();
+        if finding_type.is_empty() {
+            return Err("finding_exists requires finding type".to_string());
+        }
+        return Ok(Predicate::FindingExists {
+            finding_type: finding_type.to_string(),
+        });
+    }
+
+    if let Some(rest) = raw.strip_prefix("session_privilege:") {
+        let level = match rest.trim().to_ascii_lowercase().as_str() {
+            "user" => SessionPrivilegeLevel::User,
+            "elevated" => SessionPrivilegeLevel::Elevated,
+            "root" => SessionPrivilegeLevel::Root,
+            _ => {
+                return Err("session_privilege must be one of: user|elevated|root".to_string());
+            }
+        };
+        return Ok(Predicate::SessionPrivilege { level });
+    }
+
+    if let Some(rest) = raw.strip_prefix("artifact_tag_match:") {
+        let tag = rest.trim();
+        if tag.is_empty() {
+            return Err("artifact_tag_match requires a tag".to_string());
+        }
+        return Ok(Predicate::ArtifactTagMatch {
+            tag: tag.to_string(),
+        });
+    }
+
+    if let Some(rest) = raw.strip_prefix("run_succeeded:") {
+        let module_name = rest.trim();
+        if module_name.is_empty() {
+            return Err("run_succeeded requires a module path".to_string());
+        }
+        return Ok(Predicate::RunSucceeded {
+            module_name: module_name.to_string(),
+        });
+    }
+
+    if let Some(rest) = raw.strip_prefix("custom_metadata_match:") {
+        let (key, value) = rest
+            .split_once('=')
+            .ok_or_else(|| "custom_metadata_match requires key=value".to_string())?;
+        let key = key.trim();
+        if key.is_empty() {
+            return Err("custom_metadata_match requires non-empty key".to_string());
+        }
+        let value = parse_metadata_value(value.trim());
+        return Ok(Predicate::CustomMetadataMatch {
+            key: key.to_string(),
+            value,
+        });
+    }
+
+    Err(
+        "unsupported predicate format; supported: finding_exists, session_privilege, artifact_tag_match, run_succeeded, custom_metadata_match"
+            .to_string(),
+    )
+}
+
+fn parse_metadata_value(raw: &str) -> MetadataValue {
+    match raw.to_ascii_lowercase().as_str() {
+        "null" => MetadataValue::Null,
+        "true" => MetadataValue::Bool(true),
+        "false" => MetadataValue::Bool(false),
+        _ => {
+            if let Ok(integer) = raw.parse::<i64>() {
+                return MetadataValue::Integer(integer);
+            }
+            MetadataValue::Text(raw.to_string())
+        }
+    }
 }
 
 fn bool_word(value: bool) -> String {
@@ -2809,11 +4066,13 @@ mod tests {
     }
 
     #[test]
-    fn command_tokens_include_clear_and_release_commands() {
+    fn command_tokens_include_core_and_campaign_commands() {
         let commands = command_tokens();
         assert!(commands.contains(&"clear"));
         assert!(commands.contains(&"cls"));
         assert!(commands.contains(&"release"));
+        assert!(commands.contains(&"campaign"));
+        assert!(commands.contains(&"objective"));
     }
 
     #[test]
@@ -2821,5 +4080,69 @@ mod tests {
         let prefixed = help_topic_candidates("re");
         assert!(prefixed.contains(&"release".to_string()));
         assert!(!prefixed.contains(&"help".to_string()));
+    }
+
+    #[test]
+    fn predicate_parser_supports_all_contract_variants() {
+        let parsed = parse_predicates(
+            "finding_exists:shell,session_privilege:root,artifact_tag_match:loot,run_succeeded:exploit/linux/telnet,test",
+        );
+        assert!(parsed.is_err(), "invalid mixed predicate list should fail");
+
+        assert!(parse_predicate("finding_exists:shell").is_ok());
+        assert!(parse_predicate("session_privilege:root").is_ok());
+        assert!(parse_predicate("artifact_tag_match:loot").is_ok());
+        assert!(parse_predicate("run_succeeded:exploit/linux/telnet").is_ok());
+        assert!(parse_predicate("custom_metadata_match:owner=red").is_ok());
+    }
+
+    #[test]
+    fn completion_suggests_campaign_objective_commands_and_ids() {
+        let registry = modules::ModuleRegistryBuilder::new()
+            .build()
+            .expect("empty registry");
+        let mut repl = Repl::new("moonlight".to_string(), registry, None);
+        let campaign_id =
+            CampaignId::parse("de305d54-75b4-431b-adb2-eb6b9e546014").expect("campaign id");
+        let objective_id =
+            ObjectiveId::parse("0f8fad5b-d9cb-469f-a165-70867728950e").expect("objective id");
+        let mut campaign =
+            Campaign::new_at(campaign_id.clone(), "operation", "", 1, None).expect("campaign");
+        campaign.add_objective(objective_id.clone());
+        repl.campaigns.insert(campaign_id.clone(), campaign);
+        let objective = Objective::new_at(
+            objective_id.clone(),
+            campaign_id.clone(),
+            "foothold",
+            "",
+            vec![],
+            vec![Predicate::FindingExists {
+                finding_type: "shell".to_string(),
+            }],
+            vec![],
+            RiskLevel::High,
+            None,
+            1,
+        )
+        .expect("objective");
+        repl.objectives.insert(objective_id.clone(), objective);
+
+        let root = repl.complete("");
+        assert!(root.candidates.contains(&"campaign".to_string()));
+        assert!(root.candidates.contains(&"objective".to_string()));
+
+        let campaign_sub = repl.complete("campaign ");
+        assert!(campaign_sub.candidates.contains(&"create".to_string()));
+        assert!(campaign_sub.candidates.contains(&"status".to_string()));
+
+        let campaign_status = repl.complete("campaign status ");
+        assert!(campaign_status
+            .candidates
+            .contains(&campaign_id.as_str().to_string()));
+
+        let objective_status = repl.complete("objective status ");
+        assert!(objective_status
+            .candidates
+            .contains(&objective_id.as_str().to_string()));
     }
 }

--- a/docs/guide/campaign_objective_operations.md
+++ b/docs/guide/campaign_objective_operations.md
@@ -1,0 +1,184 @@
+# Campaign and Objective Operations Guide
+
+This guide explains how to operate campaigns and objectives from the Moonlight REPL without reading source code.
+
+## Command Usage
+
+### Campaign Commands
+
+```text
+moonlight> campaign create <name> [description] [--yes]
+moonlight> campaign list
+moonlight> campaign show <campaign-id>
+moonlight> campaign status
+moonlight> campaign status <campaign-id>
+moonlight> campaign status <campaign-id> <active|paused|completed|failed> [--yes]
+```
+
+### Objective Commands
+
+```text
+moonlight> objective create <campaign-id> <name> --success <predicate[,predicate...]> [--failure <predicate[,predicate...]>] [--risk <low|medium|high>] [--noise-budget <n>] [--description <text>] [--yes]
+moonlight> objective link-prereq <objective-id> <prerequisite-id> [--yes]
+moonlight> objective list [campaign-id]
+moonlight> objective status
+moonlight> objective status <objective-id>
+moonlight> objective status <objective-id> <start|evaluate> [--yes]
+```
+
+### Output Mode
+
+Use machine-friendly output for scripts:
+
+```text
+moonlight> output json
+```
+
+In JSON mode, command responses include stable CLI codes (for example `ML-CLI-0000` for success, `ML-CLI-0004` for policy denial).
+
+## Quick Operator Flow
+
+```text
+moonlight> campaign create operation-alpha "Internal operation" --yes
+moonlight> campaign list
+moonlight> objective create <campaign-id> foothold --success finding_exists:shell_access --risk high --yes
+moonlight> objective create <campaign-id> post-exploit --success finding_exists:post_access --risk medium
+moonlight> objective link-prereq <post-objective-id> <foothold-objective-id>
+moonlight> objective status <foothold-objective-id> start --yes
+moonlight> objective status <foothold-objective-id> evaluate
+moonlight> objective status
+moonlight> campaign status <campaign-id> paused
+moonlight> campaign status <campaign-id> completed --yes
+```
+
+## Transition Behavior
+
+### Campaign State Machine
+
+- `active -> paused`
+- `active -> completed`
+- `active -> failed`
+- `paused -> active`
+- `paused -> completed`
+- `paused -> failed`
+
+Notes:
+
+- `completed` and `failed` are terminal.
+- Terminal transitions require explicit intent (confirmation or `--yes`) via policy guardrails.
+
+### Objective State Machine
+
+- `pending -> eligible`
+- `eligible -> in_progress`
+- `in_progress -> achieved`
+- `in_progress -> failed`
+
+Rules:
+
+- `eligible` requires all prerequisites to be achieved.
+- `achieved` requires success criteria to be satisfied.
+- `failed` requires failure criteria to be satisfied.
+- No silent transitions are allowed.
+
+## Predicate Examples
+
+Supported predicate formats:
+
+- `finding_exists:<finding-type>`
+- `session_privilege:<user|elevated|root>`
+- `artifact_tag_match:<tag>`
+- `run_succeeded:<module-path>`
+- `custom_metadata_match:<key>=<value>`
+
+Examples:
+
+```text
+--success finding_exists:shell_access
+--success session_privilege:root
+--success artifact_tag_match:loot
+--success run_succeeded:exploit/linux/telnet/gnu_inetutils_telnetd_auth_bypass
+--success custom_metadata_match:owner=red
+--failure custom_metadata_match:fail=true
+```
+
+Multiple predicates:
+
+```text
+--success finding_exists:shell_access,session_privilege:root
+--failure custom_metadata_match:fail=true,finding_exists:tripwire
+```
+
+## Recovery and Replay Semantics
+
+- Objective evaluations are deterministic and event-driven.
+- Ingestion dispatch is idempotent by event key (duplicate source event keys do not re-apply state changes).
+- Campaign/objective state can be reconstructed from audit history using replay projection.
+- Replay consistency compares reconstructed state against persisted control-state snapshots.
+- On restart, control state and orchestrator snapshots are reloaded and resumed with deterministic behavior.
+
+Operational meaning:
+
+- Re-running evaluation on the same snapshot yields the same result.
+- Restarting does not require manual state repair for campaigns/objectives.
+
+## Troubleshooting
+
+### `ML-CLI-0001` Usage errors
+
+Cause:
+
+- Missing required arguments or invalid command form.
+
+Fix:
+
+- Run `help campaign` or `help objective`.
+- Use the exact command signatures shown above.
+
+### `ML-CLI-0003` Validation errors
+
+Common causes:
+
+- Invalid UUID format for campaign/objective IDs.
+- Invalid predicate syntax.
+- Invalid state transition (for example terminal-to-active).
+- Prerequisite cycle or cross-campaign prerequisite linkage.
+
+Fix:
+
+- Verify IDs are canonical UUIDs.
+- Validate predicate format.
+- Confirm transition is legal in the state matrix.
+
+### `ML-CLI-0004` Policy denied
+
+Common causes:
+
+- High-risk objective create/start without required capability.
+- Terminal campaign status change without explicit intent.
+
+Fix:
+
+- Enable required capability:
+
+```text
+moonlight> policy enable exploit_execution
+```
+
+- Re-run with explicit confirmation or `--yes`.
+
+### Replay/rollback compatibility failures
+
+Symptoms:
+
+- Release rollback apply fails with payload compatibility error.
+
+Fix:
+
+- Create a fresh rollback snapshot from current version:
+
+```text
+moonlight> release rollback snapshot pre-change
+```
+
+- Re-run `release check` and ensure rollback payload compatibility is reported as true.

--- a/docs/guide/modules.md
+++ b/docs/guide/modules.md
@@ -127,6 +127,8 @@ Command assistance:
 moonlight> help
 moonlight> help run
 moonlight> help sessions
+moonlight> help campaign
+moonlight> help objective
 moonlight> clear
 ```
 
@@ -144,6 +146,13 @@ The prompt reflects the active module when one is selected:
 ```
 moonlight(nops/riscv32le/simple)>
 ```
+
+## Campaign and Objective REPL Usage
+Campaign and objective orchestration commands are documented in:
+
+- `docs/guide/campaign_objective_operations.md`
+
+Use this guide for campaign lifecycle commands, objective predicate syntax, replay/recovery semantics, and troubleshooting.
 
 ## Performance
 Keep modules efficient and avoid expensive initialization in `run`. If a module performs heavy work, consider lazy initialization and reuse internal state.

--- a/docs/guide/release_operations.md
+++ b/docs/guide/release_operations.md
@@ -29,6 +29,7 @@ What it does:
 - Evaluates documentation completeness gates.
 - Validates migration path from current schema to latest schema.
 - Verifies rollback snapshot availability.
+- Verifies rollback snapshot payload compatibility with schema semantics.
 - Evaluates checklist requirements and reports blockers.
 
 ### Compatibility Matrix
@@ -97,8 +98,13 @@ moonlight> release rollback apply <snapshot-id>
 
 What it does:
 - Validates snapshot checksum.
+- Validates snapshot payload compatibility with target schema.
 - Restores control-state schema version from snapshot.
 - Records restore in migration history.
+
+Schema note:
+- For schema `v5+`, rollback snapshots include campaign/objective envelope fields.
+- Incompatible payloads are rejected deterministically before restore.
 
 ### Prune snapshots
 
@@ -115,6 +121,9 @@ Documentation gates verify that required usage docs exist and include required h
 Current gates:
 - `docs/guide/modules.md`
 - `docs/guide/release_operations.md`
+
+Related operator guide:
+- `docs/guide/campaign_objective_operations.md`
 
 Gate behavior:
 - Fails when required files are missing.


### PR DESCRIPTION
## Summary
This PR introduces a full Campaign & Objective modeling layer to Moonlight’s control plane, built for deterministic behavior, strict state transitions, replay/recovery safety, and operator usability.

## What’s Included
1. Core domain contracts and state machines for `Campaign` and `Objective`.
2. Serializable, deterministic predicate model and pure evaluation engine.
3. Objective lifecycle evaluation driven by prerequisites and success/failure criteria.
4. Typed campaign/objective event lineage integrated into immutable event pipeline.
5. Ingestion-time, idempotent objective re-evaluation on relevant domain events.
6. Versioned control-state persistence for campaign/objective snapshots.
7. Replay projector + restart recovery consistency checks.
8. REPL command surface for campaign/objective operations (human + JSON output).
9. Policy/capability guardrail hooks for sensitive mutations and high-risk flows.
10. Migration and rollback compatibility for the new state schema.
11. Expanded test matrix for determinism, replay equivalence, idempotency, and races.
12. Operational usage docs and updated help references:
   - `docs/guide/campaign_objective_operations.md`
   - help linkage updates in REPL and guide docs.

## Operator Outcomes
- Campaign/objective workflows are fully script-safe and interactive-safe.
- State transitions are explicit, auditable, and non-ambiguous.
- Replay and restart produce deterministic outcomes.
- Operators can run campaign/objective flows without reading source code.

## Validation
- `cargo fmt --all`
- `cargo test` passed on this branch (warnings only, no test failures).